### PR TITLE
[py] inference + reranking interfaces

### DIFF
--- a/topk-protos/src/data/v1/query_ext.rs
+++ b/topk-protos/src/data/v1/query_ext.rs
@@ -43,6 +43,16 @@ impl Stage {
             stage: Some(stage::Stage::Count(stage::CountStage {})),
         }
     }
+
+    pub fn rerank(model: Option<String>, query: Option<String>, fields: Vec<String>) -> Self {
+        Stage {
+            stage: Some(stage::Stage::Rerank(stage::RerankStage {
+                model,
+                query,
+                fields,
+            })),
+        }
+    }
 }
 
 impl stage::select_stage::SelectExpr {
@@ -402,6 +412,17 @@ impl FunctionExpr {
     pub fn bm25_score() -> Self {
         FunctionExpr {
             func: Some(function_expr::Func::Bm25Score(function_expr::Bm25Score {})),
+        }
+    }
+
+    pub fn semantic_similarity(field: impl Into<String>, query: String) -> Self {
+        FunctionExpr {
+            func: Some(function_expr::Func::SemanticSimilarity(
+                function_expr::SemanticSimilarity {
+                    field: field.into(),
+                    query,
+                },
+            )),
         }
     }
 }

--- a/topk-py/src/data/function_expr.rs
+++ b/topk-py/src/data/function_expr.rs
@@ -20,8 +20,8 @@ impl Into<topk_protos::v1::data::Vector> for VectorQuery {
 #[derive(Debug, Clone)]
 pub enum FunctionExpression {
     KeywordScore {},
-
     VectorScore { field: String, query: VectorQuery },
+    SemanticSimilarity { field: String, query: String },
 }
 
 impl Into<topk_protos::v1::data::FunctionExpr> for FunctionExpression {
@@ -32,6 +32,9 @@ impl Into<topk_protos::v1::data::FunctionExpr> for FunctionExpression {
             }
             FunctionExpression::VectorScore { field, query } => {
                 topk_protos::v1::data::FunctionExpr::vector_distance(field, query.into())
+            }
+            FunctionExpression::SemanticSimilarity { field, query } => {
+                topk_protos::v1::data::FunctionExpr::semantic_similarity(field, query)
             }
         }
     }

--- a/topk-py/src/data/query.rs
+++ b/topk-py/src/data/query.rs
@@ -120,6 +120,26 @@ impl Query {
         })
     }
 
+    #[pyo3(signature = (model=None, query=None, fields=vec![]))]
+    pub fn rerank(
+        &self,
+        model: Option<String>,
+        query: Option<String>,
+        fields: Vec<String>,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            stages: [
+                self.stages.clone(),
+                vec![Stage::Rerank {
+                    model,
+                    query,
+                    fields,
+                }],
+            ]
+            .concat(),
+        })
+    }
+
     pub fn count(&self) -> PyResult<Self> {
         Ok(Self {
             stages: [self.stages.clone(), vec![Stage::Count {}]].concat(),

--- a/topk-py/src/data/stage.rs
+++ b/topk-py/src/data/stage.rs
@@ -19,6 +19,11 @@ pub enum Stage {
         asc: bool,
     },
     Count {},
+    Rerank {
+        model: Option<String>,
+        query: Option<String>,
+        fields: Vec<String>,
+    },
 }
 
 impl Into<topk_protos::v1::data::Stage> for Stage {
@@ -28,6 +33,11 @@ impl Into<topk_protos::v1::data::Stage> for Stage {
             Stage::Filter { expr } => topk_protos::v1::data::Stage::filter(expr),
             Stage::TopK { expr, k, asc } => topk_protos::v1::data::Stage::topk(expr.into(), k, asc),
             Stage::Count {} => topk_protos::v1::data::Stage::count(),
+            Stage::Rerank {
+                model,
+                query,
+                fields,
+            } => topk_protos::v1::data::Stage::rerank(model, query, fields),
         }
     }
 }

--- a/topk-py/src/query.rs
+++ b/topk-py/src/query.rs
@@ -72,6 +72,7 @@ pub fn r#match(
 pub fn fn_pymodule(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(bm25_score))?;
     m.add_wrapped(wrap_pyfunction!(vector_distance))?;
+    m.add_wrapped(wrap_pyfunction!(semantic_similarity))?;
 
     Ok(())
 }
@@ -127,4 +128,12 @@ pub fn vector_distance(
             VectorQueryArg::U8(values) => VectorQuery::U8(values),
         },
     }
+}
+
+#[pyfunction]
+pub fn semantic_similarity(
+    field: String,
+    query: String,
+) -> data::function_expr::FunctionExpression {
+    data::function_expr::FunctionExpression::SemanticSimilarity { field, query }
 }

--- a/topk-py/src/schema.rs
+++ b/topk-py/src/schema.rs
@@ -23,6 +23,7 @@ pub fn pymodule(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // indexes
     m.add_wrapped(wrap_pyfunction!(vector_index))?;
     m.add_wrapped(wrap_pyfunction!(keyword_index))?;
+    m.add_wrapped(wrap_pyfunction!(semantic_index))?;
 
     Ok(())
 }
@@ -99,4 +100,10 @@ pub fn keyword_index(r#type: String) -> PyResult<control::field_index::FieldInde
     };
 
     Ok(control::field_index::FieldIndex::KeywordIndex { index_type })
+}
+
+#[pyfunction]
+#[pyo3(signature=(model=None))]
+pub fn semantic_index(model: Option<String>) -> PyResult<control::field_index::FieldIndex> {
+    Ok(control::field_index::FieldIndex::SemanticIndex { model })
 }

--- a/topk-py/tests/__init__.py
+++ b/topk-py/tests/__init__.py
@@ -18,13 +18,13 @@ def new_project_context():
     TOPK_API_KEY = os.environ["TOPK_API_KEY"].splitlines()[0].strip()
     TOPK_HOST = os.environ.get("TOPK_HOST", "topk.io")
     TOPK_REGION = os.environ.get("TOPK_REGION", "elastica")
-    TOPK_HTTPS = os.environ.get("TOPK_HTTPS", "true") == "true"
+    TOPK_HTTPS = os.environ.get("TOPK_HTTPS", "false") == "true"
 
     client = Client(
         api_key=TOPK_API_KEY,
         region=TOPK_REGION,
         host=TOPK_HOST,
-        https=TOPK_HTTPS
+        https=TOPK_HTTPS,
     )
 
     return ProjectContext(

--- a/topk-py/tests/test_collections.py
+++ b/topk-py/tests/test_collections.py
@@ -8,6 +8,7 @@ from topk_sdk.schema import (
     float,
     int,
     keyword_index,
+    semantic_index,
     text,
     u8_vector,
     vector_index,
@@ -22,6 +23,7 @@ def test_create_collection(ctx: ProjectContext):
         "title_embedding": f32_vector(1536)
         .required()
         .index(vector_index(metric="euclidean")),
+        "summary": text().required().index(semantic_index()),
         "published_year": int().required(),
     }
 


### PR DESCRIPTION
* add `semantic_index(model: Optional[str] = None)` constructor for defining semantic indexes in collection schema
* add `.rerank(model: Optional[str] = None, query: Optional[str] = None, fields: list[str] = [])` method for creating a `rerank` stage
* add tests exercising these