### PR TITLE
improve python tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Pull Request
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   python:
-    name: Python
+    name: Test Python
     runs-on: [earthly-satellite#bob-the-builder-amd64]
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ready') }}
     permissions:
@@ -24,10 +24,10 @@ jobs:
         env:
           TOPK_API_KEY: ${{ secrets.TOPK_API_KEY }}
 
-  success:
-    name: Success
+  ready:
+    name: Ready
     needs: [python]
     runs-on: ubuntu-latest
     steps:
-      - name: Success
-        run: echo "Success"
+      - name: Ready
+        run: echo "Ready"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Python tests
-        run: earthly --secret TOPK_API_KEY +test-py
+        run: earthly --secret TOPK_API_KEY +test-py --region elastica
         env:
           TOPK_API_KEY: ${{ secrets.TOPK_API_KEY }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test SDKs
+name: Test
 
 on:
   pull_request:
@@ -6,6 +6,7 @@ on:
 
 jobs:
   python:
+    name: Python
     runs-on: [earthly-satellite#bob-the-builder-amd64]
     if: ${{ github.event.label.name == 'ready' }}
     permissions:
@@ -20,3 +21,13 @@ jobs:
 
       - name: Python tests
         run: earthly --secret TOPK_API_KEY +test-py
+        env:
+          TOPK_API_KEY: ${{ secrets.TOPK_API_KEY }}
+
+  success:
+    name: Success
+    needs: [python]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Success
+        run: echo "Success"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
   python:
     name: Python
     runs-on: [earthly-satellite#bob-the-builder-amd64]
-    if: ${{ contains(github.event.pull_request.labels, 'ready') }}
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ready') }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,13 +2,13 @@ name: Test
 
 on:
   pull_request:
-    types: [labeled]
+    types: [synchronize, opened, reopened, labeled, unlabeled]
 
 jobs:
   python:
     name: Python
     runs-on: [earthly-satellite#bob-the-builder-amd64]
-    if: ${{ github.event.label.name == 'ready' }}
+    if: ${{ contains(github.event.pull_request.labels, 'ready') }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test SDKs
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  python:
+    runs-on: [earthly-satellite#bob-the-builder-amd64]
+    if: ${{ github.event.label.name == 'ready' }}
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    env:
+      FORCE_COLOR: 1
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Python tests
+        run: earthly --secret TOPK_API_KEY +test-py

--- a/Earthfile
+++ b/Earthfile
@@ -15,14 +15,18 @@ test-py:
     RUN python3 -m venv .venv \
         && . .venv/bin/activate \
         && pip install --upgrade pip \
-        && pip install pytest
+        && pip install pytest pytest-xdist
 
     # copy source code
     COPY . .
 
     # build
     WORKDIR /sdk/topk-py
-    RUN --mount=type=cache,target=/sdk/topk-py/target --mount=type=cache,target=/root/.cargo maturin develop
+    RUN --mount=type=cache,target=/sdk/topk-py/target \
+        --mount=type=cache,target=/root/.cargo \
+        --mount=type=cache,target=/usr/local/cargo/registry \
+        --mount=type=cache,target=/usr/local/cargo/git \
+        maturin develop
 
     # region
     ARG region=dev
@@ -37,6 +41,6 @@ test-py:
     END
 
     # test
-    RUN --secret TOPK_API_KEY \
+    RUN --no-cache --secret TOPK_API_KEY \
         . /sdk/.venv/bin/activate \
-        && TOPK_API_KEY=$TOPK_API_KEY pytest
+        && TOPK_API_KEY=$TOPK_API_KEY pytest -n auto

--- a/Earthfile
+++ b/Earthfile
@@ -1,13 +1,42 @@
 VERSION 0.8
 
-test:
-    LOCALLY
+test-py:
+    FROM rust:slim
+
+    # install dependencies
+    RUN apt-get update && apt-get install -y protobuf-compiler python3.11-venv
+
+    # setup maturin
     RUN cargo install maturin
 
-    WORKDIR topk-py
+    WORKDIR /sdk
 
+    # setup python
     RUN python3 -m venv .venv \
         && . .venv/bin/activate \
-        && pip install pytest \
-        && maturin develop \
-        && pytest
+        && pip install --upgrade pip \
+        && pip install pytest
+
+    # copy source code
+    COPY . .
+
+    # build
+    WORKDIR /sdk/topk-py
+    RUN --mount=type=cache,target=/sdk/topk-py/target --mount=type=cache,target=/root/.cargo maturin develop
+
+    # region
+    ARG region=dev
+    ENV TOPK_REGION=$region
+
+    # setup dev environment
+    IF [ "$region" = "dev" ]
+        # forward traffic to dev cluster running on host
+        LET host_ip=$(getent hosts host.docker.internal | awk '{ print $1 }')
+        HOST dev.api.ddb $host_ip
+        ENV TOPK_HOST=ddb
+    END
+
+    # test
+    RUN --secret TOPK_API_KEY \
+        . /sdk/.venv/bin/activate \
+        && TOPK_API_KEY=$TOPK_API_KEY pytest

--- a/Earthfile
+++ b/Earthfile
@@ -38,6 +38,7 @@ test-py:
         LET host_ip=$(getent hosts host.docker.internal | awk '{ print $1 }')
         HOST dev.api.ddb $host_ip
         ENV TOPK_HOST=ddb
+        ENV TOPK_HTTPS=false
     END
 
     # test

--- a/README.md
+++ b/README.md
@@ -2,15 +2,27 @@
 
 This repository contains TopK SDKs for different languages. Python is the only SDK that is currently supported, with Rust coming soon.
 
-## Development
+## Running tests
 
 1. Install [Earthly](https://earthly.dev/get-earthly)
-2. Install [Python](https://www.python.org/downloads/)
-3. Install [Rust](https://www.rust-lang.org/tools/install)
-4. Install [maturin](https://github.com/pyo3/maturin)
-5. Run tests in development mode
+1. Run `python` tests
    ```bash
-   earthly +test
+   earthly --secret TOPK_API_KEY +test-py
+   ```
+
+## Python development
+
+1. Install [Python](https://www.python.org/downloads/)
+1. Install [maturin](https://github.com/pyo3/maturin)
+1. Install [pytest](https://github.com/pytest-dev/pytest)
+1. `cd topk-py`
+1. Build the sdk
+   ```bash
+   maturin develop
+   ```
+1. Run tests
+   ```bash
+   pytest
    ```
 
 ## Release

--- a/topk-py/src/client.rs
+++ b/topk-py/src/client.rs
@@ -12,6 +12,7 @@ use crate::{
         query::{ConsistencyLevel, Query},
         value::ValueUnion,
     },
+    error::DocumentNotFoundError,
 };
 
 #[pyclass]
@@ -150,10 +151,7 @@ impl CollectionClient {
                 consistency.map(|c| c.into()),
             ))
             .map_err(|e| match e {
-                topk_rs::Error::DocumentNotFound => {
-                    // TODO: use pyo3 exception
-                    PyException::new_err(format!("document not found"))
-                }
+                topk_rs::Error::DocumentNotFound => DocumentNotFoundError::new_err(e.to_string()),
                 _ => PyException::new_err(format!("failed to get document: {:?}", e)),
             })?;
 

--- a/topk-py/src/schema.rs
+++ b/topk-py/src/schema.rs
@@ -106,10 +106,25 @@ pub fn keyword_index(r#type: String) -> PyResult<control::field_index::FieldInde
 #[pyo3(signature=(model=None, embedding_type=None))]
 pub fn semantic_index(
     model: Option<String>,
-    embedding_type: Option<EmbeddingDataType>,
+    embedding_type: Option<String>,
 ) -> PyResult<control::field_index::FieldIndex> {
+    let embedding_type = match embedding_type {
+        Some(embedding_type) => match embedding_type.as_str() {
+            "f32" => Some(EmbeddingDataType::Float32),
+            "u8" => Some(EmbeddingDataType::UInt8),
+            "binary" => Some(EmbeddingDataType::Binary),
+            _ => {
+                return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "Invalid embedding type: {}",
+                    embedding_type
+                )))
+            }
+        },
+        None => None,
+    };
+
     Ok(control::field_index::FieldIndex::SemanticIndex {
         model,
-        embedding_type,
+        embedding_type: embedding_type.into(),
     })
 }

--- a/topk-py/tests/__init__.py
+++ b/topk-py/tests/__init__.py
@@ -18,7 +18,7 @@ def new_project_context():
     TOPK_API_KEY = os.environ["TOPK_API_KEY"].splitlines()[0].strip()
     TOPK_HOST = os.environ.get("TOPK_HOST", "topk.io")
     TOPK_REGION = os.environ.get("TOPK_REGION", "elastica")
-    TOPK_HTTPS = os.environ.get("TOPK_HTTPS", "false") == "true"
+    TOPK_HTTPS = os.environ.get("TOPK_HTTPS", "true") == "true"
 
     print(
         dict(

--- a/topk-py/tests/__init__.py
+++ b/topk-py/tests/__init__.py
@@ -20,6 +20,15 @@ def new_project_context():
     TOPK_REGION = os.environ.get("TOPK_REGION", "elastica")
     TOPK_HTTPS = os.environ.get("TOPK_HTTPS", "false") == "true"
 
+    print(
+        dict(
+            api_key=TOPK_API_KEY,
+            region=TOPK_REGION,
+            host=TOPK_HOST,
+            https=TOPK_HTTPS,
+        )
+    )
+
     client = Client(
         api_key=TOPK_API_KEY,
         region=TOPK_REGION,

--- a/topk-py/tests/test_collections.py
+++ b/topk-py/tests/test_collections.py
@@ -23,7 +23,9 @@ def test_create_collection(ctx: ProjectContext):
         "title_embedding": f32_vector(1536)
         .required()
         .index(vector_index(metric="euclidean")),
-        "summary": text().required().index(semantic_index()),
+        "summary": text()
+        .required()
+        .index(semantic_index(model="dummy", embedding_type="f32")),
         "published_year": int().required(),
     }
 

--- a/topk-py/tests/test_documents.py
+++ b/topk-py/tests/test_documents.py
@@ -181,7 +181,7 @@ def test_semantic_search(ctx: ProjectContext):
     ctx.client.collections().create(
         ctx.scope("books"),
         schema={
-            "title": text().required().index(semantic_index(model="something-made-up")),
+            "title": text().required().index(semantic_index(model="dummy")),
         },
     )
 
@@ -205,7 +205,8 @@ def test_semantic_search(ctx: ProjectContext):
         lsn=lsn,
     )
 
-    assert {d["_id"] for d in docs} == {"doc1", "doc2"}
+    # NOTE: since we are using the dummy model, the similarity score is randomized, so we can't check ordering. Instead we check the length of `docs`.
+    assert len(docs) == 2
 
 
 def test_delete(ctx: ProjectContext):
@@ -253,7 +254,7 @@ def test_rerank(ctx: ProjectContext):
     ctx.client.collections().create(
         ctx.scope("books"),
         schema={
-            "summary": text().required().index(semantic_index()),
+            "summary": text().required().index(semantic_index(model="dummy")),
         },
     )
 
@@ -276,7 +277,9 @@ def test_rerank(ctx: ProjectContext):
         .rerank(),
         lsn=lsn,
     )
-    assert [d["_id"] for d in docs] == ["doc1", "doc4"]
+
+    # NOTE: since we are using the dummy model, the similarity score is randomized, so we can't check ordering. Instead we check the length of `docs`.
+    assert len(docs) == 2
 
 
 @pytest.fixture


### PR DESCRIPTION
* adjust python tests to account for dummy embedder/reranked (by not asserting ordering)
* add `earthly --secret TOPK_API_KEY +test-py` entrypoint for easier test running
* add CI for python when PR is labeled with `ready`
