### PR TITLE
add `topk-rs` tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,25 @@ on:
     types: [synchronize, opened, reopened, labeled, unlabeled]
 
 jobs:
+  rust:
+    name: Test Rust
+    runs-on: [earthly-satellite#bob-the-builder-amd64]
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ready') }}
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    env:
+      FORCE_COLOR: 1
+      EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Rust tests
+        run: earthly --secret TOPK_API_KEY +test-rs --region elastica
+        env:
+          TOPK_API_KEY: ${{ secrets.TOPK_API_KEY }}
+
   python:
     name: Test Python
     runs-on: [earthly-satellite#bob-the-builder-amd64]
@@ -17,7 +36,7 @@ jobs:
       FORCE_COLOR: 1
       EARTHLY_TOKEN: "${{ secrets.EARTHLY_TOKEN }}"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Python tests
         run: earthly --secret TOPK_API_KEY +test-py --region elastica
@@ -26,7 +45,7 @@ jobs:
 
   ready:
     name: Ready
-    needs: [python]
+    needs: [rust, python]
     runs-on: ubuntu-latest
     steps:
       - name: Ready

--- a/topk-rs/Cargo.toml
+++ b/topk-rs/Cargo.toml
@@ -17,3 +17,7 @@ thiserror = { version = "1.0.65" }
 tracing = { version = "0.1.40" }
 serde_json = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+test-context = { version = "0.3.0" }
+uuid = { version = "1.10.0", features = ["v4"] }

--- a/topk-rs/tests/test_collection.rs
+++ b/topk-rs/tests/test_collection.rs
@@ -1,0 +1,136 @@
+use std::collections::HashMap;
+use test_context::test_context;
+use topk_rs::Error;
+
+mod utils;
+use utils::ProjectTestContext;
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_list_collections(ctx: &mut ProjectTestContext) {
+    let c = ctx
+        .client
+        .collections()
+        .create(ctx.wrap("test"), HashMap::default())
+        .await
+        .expect("could not create collection");
+
+    let response = ctx
+        .client
+        .collections()
+        .list()
+        .await
+        .expect("could not list collections");
+
+    assert!(response.iter().any(|cc| cc == &c));
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_create_collection(ctx: &mut ProjectTestContext) {
+    let c = ctx
+        .client
+        .collections()
+        .create(ctx.wrap("test"), HashMap::default())
+        .await
+        .expect("could not create collection");
+
+    let collections = ctx
+        .client
+        .collections()
+        .list()
+        .await
+        .expect("could not list collections");
+
+    assert!(collections.iter().any(|cc| cc == &c));
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_create_duplicate_collection(ctx: &mut ProjectTestContext) {
+    ctx.client
+        .collections()
+        .create(ctx.wrap("test"), HashMap::default())
+        .await
+        .expect("could not create collection");
+
+    let err = ctx
+        .client
+        .collections()
+        .create(ctx.wrap("test"), HashMap::default())
+        .await
+        .expect_err("should not be able to create duplicate collection");
+
+    assert!(matches!(err, Error::CollectionAlreadyExists));
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_delete_non_existent_collection(ctx: &mut ProjectTestContext) {
+    let err = ctx
+        .client
+        .collections()
+        .delete(ctx.wrap("test"))
+        .await
+        .expect_err("should not be able to delete non-existent collection");
+
+    assert!(matches!(err, Error::CollectionNotFound));
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_delete_collection(ctx: &mut ProjectTestContext) {
+    let c = ctx
+        .client
+        .collections()
+        .create(ctx.wrap("test"), HashMap::default())
+        .await
+        .expect("could not create collection");
+
+    ctx.client
+        .collections()
+        .delete(ctx.wrap("test"))
+        .await
+        .expect("could not delete collection");
+
+    let collections = ctx
+        .client
+        .collections()
+        .list()
+        .await
+        .expect("could not list collections");
+
+    assert!(!collections.iter().any(|cc| *cc == c));
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_get_collection(ctx: &mut ProjectTestContext) {
+    // Test getting non-existent collection
+    let err = ctx
+        .client
+        .collections()
+        .get(ctx.wrap("test"))
+        .await
+        .expect_err("should not be able to get non-existent collection");
+
+    assert!(matches!(err, Error::CollectionNotFound));
+
+    // Create collection
+    let c = ctx
+        .client
+        .collections()
+        .create(ctx.wrap("test"), HashMap::default())
+        .await
+        .expect("could not create collection");
+
+    // Get collection
+    let collection = ctx
+        .client
+        .collections()
+        .get(ctx.wrap("test"))
+        .await
+        .expect("could not get collection");
+
+    assert_eq!(collection, c);
+}

--- a/topk-rs/tests/test_delete.rs
+++ b/topk-rs/tests/test_delete.rs
@@ -1,0 +1,96 @@
+use std::collections::{HashMap, HashSet};
+use test_context::test_context;
+use topk_protos::doc;
+use topk_protos::v1::data::{LogicalExpr, Query, Stage};
+use topk_rs::Error;
+
+mod utils;
+use utils::ProjectTestContext;
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_delete_from_non_existent_collection(ctx: &mut ProjectTestContext) {
+    let err = ctx
+        .client
+        .collection("missing")
+        .delete(vec!["one".to_string()])
+        .await
+        .expect_err("should not be able to delete document from non-existent collection");
+
+    assert!(matches!(err, Error::CollectionNotFound));
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_delete_document(ctx: &mut ProjectTestContext) {
+    let collection = ctx
+        .client
+        .collections()
+        .create(ctx.wrap("test"), HashMap::default())
+        .await
+        .expect("could not create collection");
+
+    let lsn = ctx
+        .client
+        .collection(&collection.name)
+        .upsert(vec![
+            doc!("_id" => "one", "rank" => 1),
+            doc!("_id" => "two", "rank" => 2),
+        ])
+        .await
+        .expect("could not upsert document");
+    assert_eq!(lsn, 1);
+
+    // wait for write to be flushed
+    ctx.client
+        .collection(&collection.name)
+        .query(Query::new(vec![Stage::count()]), None, None)
+        .await
+        .expect("could not query documents");
+
+    let lsn = ctx
+        .client
+        .collection(&collection.name)
+        .delete(vec!["one".to_string()])
+        .await
+        .expect("could not delete document");
+    assert_eq!(lsn, 2);
+
+    let docs = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![Stage::topk(LogicalExpr::field("rank"), 100, true)]),
+            Some(lsn),
+            None,
+        )
+        .await
+        .expect("could not query documents");
+
+    assert_eq!(
+        docs.into_iter()
+            .map(|d| d.id().unwrap().to_string())
+            .collect::<HashSet<_>>(),
+        ["two".to_string()].into()
+    );
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_delete_non_existent_document(ctx: &mut ProjectTestContext) {
+    let collection = ctx
+        .client
+        .collections()
+        .create(ctx.wrap("test"), HashMap::default())
+        .await
+        .expect("could not create collection");
+
+    // we can delete a non-existent document, and it will be ignored
+    let lsn = ctx
+        .client
+        .collection(&collection.name)
+        .delete(vec!["one".to_string()])
+        .await
+        .expect("could not delete document");
+    assert_eq!(lsn, 1);
+}

--- a/topk-rs/tests/test_get.rs
+++ b/topk-rs/tests/test_get.rs
@@ -1,0 +1,80 @@
+use test_context::test_context;
+use topk_protos::doc;
+use topk_rs::Error;
+
+mod utils;
+use utils::dataset;
+use utils::ProjectTestContext;
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_get_from_non_existent_collection(ctx: &mut ProjectTestContext) {
+    let err = ctx
+        .client
+        .collection("missing")
+        .get("doc1", vec![], None, None)
+        .await
+        .expect_err("should not be able to get document from non-existent collection");
+
+    // TODO: this should return `CollectionNotFound`
+    assert!(matches!(err, Error::DocumentNotFound));
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_get_non_existent_document(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let err = ctx
+        .client
+        .collection(&collection.name)
+        .get("missing", vec![], None, None)
+        .await
+        .expect_err("should not be able to get non-existent document");
+
+    assert!(matches!(err, Error::DocumentNotFound));
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_get_document(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let lotr = dataset::books::docs()
+        .into_iter()
+        .find(|doc| doc.id().unwrap() == "lotr")
+        .clone()
+        .unwrap();
+
+    let doc = ctx
+        .client
+        .collection(&collection.name)
+        .get("lotr", vec![], None, None)
+        .await
+        .expect("could not get document");
+
+    assert_eq!(doc, lotr);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_get_document_fields(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let doc = ctx
+        .client
+        .collection(&collection.name)
+        .get(
+            "lotr",
+            vec!["title".to_string(), "published_year".to_string()],
+            None,
+            None,
+        )
+        .await
+        .expect("could not get document");
+
+    assert_eq!(
+        doc,
+        doc!("_id" => "lotr", "title" => "The Lord of the Rings: The Fellowship of the Ring", "published_year" => 1954 as u32)
+    );
+}

--- a/topk-rs/tests/test_query_count.rs
+++ b/topk-rs/tests/test_query_count.rs
@@ -1,0 +1,92 @@
+use test_context::test_context;
+use topk_protos::{
+    doc,
+    v1::data::{stage::filter_stage::FilterExpr, LogicalExpr, Query, Stage},
+};
+use topk_rs::Error;
+
+mod utils;
+use utils::dataset;
+use utils::ProjectTestContext;
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_non_existent_collection(ctx: &mut ProjectTestContext) {
+    let err = ctx
+        .client
+        .collection("missing")
+        .query(Query::new(vec![Stage::count()]), None, None)
+        .await
+        .expect_err("should not be able to query non-existent collection");
+
+    assert!(matches!(err, Error::CollectionNotFound));
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_count(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(Query::new(vec![Stage::count()]), None, None)
+        .await
+        .expect("could not query");
+
+    assert_eq!(result, vec![doc!("_count" => 10_u64)]);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_count_with_filter(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let query = Query::new(vec![
+        Stage::filter(FilterExpr::logical(LogicalExpr::lte(
+            LogicalExpr::field("published_year"),
+            LogicalExpr::literal((1950 as u32).into()),
+        ))),
+        Stage::count(),
+    ]);
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(query, None, None)
+        .await
+        .expect("could not query");
+
+    assert_eq!(result, vec![doc!("_count" => 5_u64)]);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_count_with_delete(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(Query::new(vec![Stage::count()]), None, None)
+        .await
+        .expect("could not query");
+
+    assert_eq!(result, vec![doc!("_count" => 10_u64)]);
+
+    let lsn = ctx
+        .client
+        .collection(&collection.name)
+        .delete(vec!["lotr".to_string()])
+        .await
+        .expect("could not delete document");
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(Query::new(vec![Stage::count()]), Some(lsn), None)
+        .await
+        .expect("could not query");
+
+    assert_eq!(result, vec![doc!("_count" => 9_u64)]);
+}

--- a/topk-rs/tests/test_query_filter.rs
+++ b/topk-rs/tests/test_query_filter.rs
@@ -1,0 +1,95 @@
+use test_context::test_context;
+use topk_protos::v1::data::{stage::filter_stage::FilterExpr, LogicalExpr, Query, Stage};
+
+mod utils;
+use utils::dataset;
+use utils::ProjectTestContext;
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_starts_with(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::filter(FilterExpr::logical(LogicalExpr::starts_with(
+                    LogicalExpr::field("_id"),
+                    LogicalExpr::literal("cat".into()),
+                ))),
+                Stage::topk(LogicalExpr::field("published_year"), 100, false),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_doc_ids!(result, ["catcher"]);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_starts_with_empty(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::filter(FilterExpr::logical(LogicalExpr::starts_with(
+                    LogicalExpr::field("_id"),
+                    LogicalExpr::literal("".into()),
+                ))),
+                Stage::topk(LogicalExpr::field("published_year"), 100, false),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_doc_ids!(
+        result,
+        [
+            "gatsby",
+            "catcher",
+            "moby",
+            "mockingbird",
+            "alchemist",
+            "harry",
+            "lotr",
+            "pride",
+            "1984",
+            "hobbit"
+        ]
+    );
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_starts_with_non_existent_prefix(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::filter(FilterExpr::logical(LogicalExpr::starts_with(
+                    LogicalExpr::field("_id"),
+                    LogicalExpr::literal("foobarbaz".into()),
+                ))),
+                Stage::topk(LogicalExpr::field("published_year"), 100, false),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert!(result.is_empty());
+}

--- a/topk-rs/tests/test_query_logical.rs
+++ b/topk-rs/tests/test_query_logical.rs
@@ -1,0 +1,62 @@
+use test_context::test_context;
+use topk_protos::v1::data::{stage::filter_stage::FilterExpr, LogicalExpr, Query, Stage};
+
+mod utils;
+use utils::dataset;
+use utils::ProjectTestContext;
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_lte(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::filter(FilterExpr::logical(LogicalExpr::lte(
+                    LogicalExpr::field("published_year"),
+                    LogicalExpr::literal((1950 as u32).into()),
+                ))),
+                Stage::topk(LogicalExpr::field("published_year"), 100, true),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_doc_ids!(result, ["1984", "pride", "hobbit", "moby", "gatsby"]);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_and(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::filter(FilterExpr::logical(LogicalExpr::and(
+                    LogicalExpr::lte(
+                        LogicalExpr::field("published_year"),
+                        LogicalExpr::literal((1950 as u32).into()),
+                    ),
+                    LogicalExpr::gte(
+                        LogicalExpr::field("published_year"),
+                        LogicalExpr::literal((1948 as u32).into()),
+                    ),
+                ))),
+                Stage::topk(LogicalExpr::field("published_year"), 100, true),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_doc_ids!(result, ["1984"]);
+}

--- a/topk-rs/tests/test_query_select.rs
+++ b/topk-rs/tests/test_query_select.rs
@@ -1,0 +1,315 @@
+use std::collections::{HashMap, HashSet};
+use test_context::test_context;
+use topk_protos::doc;
+use topk_protos::v1::data::{
+    stage::{filter_stage::FilterExpr, select_stage::SelectExpr},
+    text_expr, FunctionExpr, Query, Stage, TextExpr,
+};
+use topk_protos::v1::data::{LogicalExpr, Value, Vector};
+
+mod utils;
+use utils::dataset;
+use utils::ProjectTestContext;
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_select_literal(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let results = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::select(HashMap::from([(
+                    "literal".to_string(),
+                    SelectExpr::logical(LogicalExpr::literal((1.0 as f32).into())),
+                )])),
+                Stage::filter(FilterExpr::logical(LogicalExpr::eq(
+                    LogicalExpr::field("title"),
+                    LogicalExpr::literal("1984".into()),
+                ))),
+                Stage::topk(LogicalExpr::field("published_year"), 100, true),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_eq!(
+        results,
+        vec![doc!("_id" => "1984", "literal" => 1.0 as f32)]
+    );
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_select_non_existing_field(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let results = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::select(HashMap::from([(
+                    "literal".to_string(),
+                    SelectExpr::logical(LogicalExpr::field("non_existing_field")),
+                )])),
+                Stage::filter(FilterExpr::logical(LogicalExpr::eq(
+                    LogicalExpr::field("title"),
+                    LogicalExpr::literal("1984".into()),
+                ))),
+                Stage::topk(LogicalExpr::field("published_year"), 100, true),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_eq!(results, vec![doc!("_id" => "1984")]);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_topk_limit(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let results = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![Stage::topk(
+                LogicalExpr::field("published_year"),
+                3,
+                true,
+            )]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+    assert_eq!(results.len(), 3);
+
+    let results = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![Stage::topk(
+                LogicalExpr::field("published_year"),
+                2,
+                true,
+            )]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+    assert_eq!(results.len(), 2);
+
+    let results = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![Stage::topk(
+                LogicalExpr::field("published_year"),
+                1,
+                true,
+            )]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+    assert_eq!(results.len(), 1);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_topk_asc(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let results = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::select(HashMap::from([(
+                    "published_year".to_string(),
+                    SelectExpr::logical(LogicalExpr::field("published_year")),
+                )])),
+                Stage::topk(LogicalExpr::field("published_year"), 3, true),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_eq!(
+        results,
+        vec![
+            doc!("_id" => "pride", "published_year" => 1813 as u32),
+            doc!("_id" => "moby", "published_year" => 1851 as u32),
+            doc!("_id" => "gatsby", "published_year" => 1925 as u32),
+        ]
+    );
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_topk_desc(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let results = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::select(HashMap::from([(
+                    "published_year".to_string(),
+                    SelectExpr::logical(LogicalExpr::field("published_year")),
+                )])),
+                Stage::topk(LogicalExpr::field("published_year"), 3, false),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_eq!(
+        results,
+        vec![
+            doc!("_id" => "harry", "published_year" => 1997 as u32),
+            doc!("_id" => "alchemist", "published_year" => 1988 as u32),
+            doc!("_id" => "mockingbird", "published_year" => 1960 as u32),
+        ]
+    );
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_select_bm25_score(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let results = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::select(HashMap::from([(
+                    "bm25_score".to_string(),
+                    SelectExpr::function(FunctionExpr::bm25_score()),
+                )])),
+                Stage::filter(FilterExpr::text(TextExpr::terms(
+                    true,
+                    vec![text_expr::Term {
+                        token: "pride".to_string(),
+                        field: None,
+                        weight: 1.0,
+                    }],
+                ))),
+                Stage::topk(LogicalExpr::field("bm25_score"), 100, true),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_eq!(
+        results,
+        vec![doc!("_id" => "pride", "bm25_score" => 2.0774152 as f32)]
+    );
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_select_vector_distance(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let results = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::select(HashMap::from([(
+                    "summary_distance".to_string(),
+                    SelectExpr::function(FunctionExpr::vector_distance(
+                        "summary_embedding".to_string(),
+                        Vector::float(vec![2.0; 16]),
+                    )),
+                )])),
+                Stage::topk(LogicalExpr::field("summary_distance"), 3, true),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    // note: purposefully not matching on `summary_distance` since the exact value changes over time as we develop the system
+    assert_eq!(results.len(), 3);
+    assert_eq!(
+        results
+            .into_iter()
+            .map(|d| d.id().unwrap().to_string())
+            .collect::<HashSet<_>>(),
+        ["1984".into(), "mockingbird".into(), "pride".into()].into()
+    );
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_select_null_field(ctx: &mut ProjectTestContext) {
+    let collection = ctx
+        .client
+        .collections()
+        .create(ctx.wrap("test"), HashMap::default())
+        .await
+        .expect("could not create collection");
+
+    ctx.client
+        .collection(&collection.name)
+        .upsert(vec![
+            doc!("_id" => "1984", "a" => Value::null()),
+            doc!("_id" => "pride"),
+        ])
+        .await
+        .expect("could not upsert documents");
+
+    let results = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::select(HashMap::from([
+                    (
+                        "a".to_string(),
+                        SelectExpr::logical(LogicalExpr::field("a")),
+                    ),
+                    (
+                        "b".to_string(),
+                        SelectExpr::logical(LogicalExpr::literal(1.into())),
+                    ),
+                ])),
+                Stage::topk(LogicalExpr::field("b"), 100, true),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    // Assert that `a` is null for all documents, even when not specified when upserting
+    assert_eq!(
+        results
+            .into_iter()
+            .map(|d| d.fields.get("a").unwrap().clone())
+            .collect::<Vec<_>>(),
+        vec![Value::null(), Value::null()]
+    );
+}

--- a/topk-rs/tests/test_query_select_union.rs
+++ b/topk-rs/tests/test_query_select_union.rs
@@ -1,0 +1,83 @@
+use std::collections::HashMap;
+use test_context::test_context;
+use topk_protos::{
+    doc,
+    v1::data::{stage::select_stage::SelectExpr, LogicalExpr, Query, Stage, Value},
+};
+
+mod utils;
+use utils::ProjectTestContext;
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_select_union(ctx: &mut ProjectTestContext) {
+    // create collection
+    let collection = ctx
+        .client
+        .collections()
+        .create(ctx.wrap("test"), HashMap::default())
+        .await
+        .expect("could not create collection");
+
+    // upsert documents
+    let lsn = ctx
+        .client
+        .collection(&collection.name)
+        .upsert(vec![
+            doc!("_id" => "0", "rank" => 0, "mixed" => Value::null()),
+            doc!("_id" => "1", "rank" => 1, "mixed" => (1 as u32)),
+            doc!("_id" => "2", "rank" => 2, "mixed" => (2 as u64)),
+            doc!("_id" => "3", "rank" => 3, "mixed" => (3 as i32)),
+            doc!("_id" => "4", "rank" => 4, "mixed" => (4 as i64)),
+            doc!("_id" => "5", "rank" => 5, "mixed" => (5 as f32)),
+            doc!("_id" => "6", "rank" => 6, "mixed" => (6 as f64)),
+            doc!("_id" => "7", "rank" => 7, "mixed" => true),
+            doc!("_id" => "8", "rank" => 8, "mixed" => "hello"),
+            doc!("_id" => "9", "rank" => 9, "mixed" => Value::byte_vector(vec![1, 2, 3])),
+            doc!("_id" => "10", "rank" => 10, "mixed" => Value::float_vector(vec![1.0, 2.0, 3.0])),
+        ])
+        .await
+        .expect("upsert failed");
+
+    // wait for writes to be flushed
+    let _ = ctx
+        .client
+        .collection(&collection.name)
+        .query(Query::new(vec![Stage::count()]), Some(lsn), None)
+        .await
+        .expect("could not query");
+
+    let results = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::select(HashMap::from([(
+                    "mixed".to_string(),
+                    SelectExpr::logical(LogicalExpr::field("mixed")),
+                )])),
+                Stage::topk(LogicalExpr::field("rank"), 100, true),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_eq!(
+        results,
+        vec![
+            doc!("_id" => "0", "mixed" => Value::null()),
+            doc!("_id" => "1", "mixed" => (1 as u32)),
+            doc!("_id" => "2", "mixed" => (2 as u64)),
+            doc!("_id" => "3", "mixed" => (3 as i32)),
+            doc!("_id" => "4", "mixed" => (4 as i64)),
+            doc!("_id" => "5", "mixed" => (5.0 as f32)),
+            doc!("_id" => "6", "mixed" => (6.0 as f64)),
+            doc!("_id" => "7", "mixed" => true),
+            doc!("_id" => "8", "mixed" => "hello"),
+            doc!("_id" => "9", "mixed" => Value::byte_vector(vec![1, 2, 3])),
+            doc!("_id" => "10", "mixed" => Value::float_vector(vec![1.0, 2.0, 3.0])),
+        ]
+    );
+}

--- a/topk-rs/tests/test_query_text.rs
+++ b/topk-rs/tests/test_query_text.rs
@@ -1,0 +1,200 @@
+use std::collections::HashMap;
+use test_context::test_context;
+use topk_protos::v1::data::{
+    stage::{filter_stage::FilterExpr, select_stage::SelectExpr},
+    text_expr::Term,
+    FunctionExpr, LogicalExpr, Query, Stage, TextExpr,
+};
+
+mod utils;
+use topk_rs::Error;
+use utils::dataset;
+use utils::ProjectTestContext;
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_text_filter_single_term_disjunctive(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::filter(FilterExpr::text(TextExpr::terms(
+                    false,
+                    vec![Term {
+                        token: "love".to_string(),
+                        field: Some("summary".to_string()),
+                        weight: 1.0,
+                    }],
+                ))),
+                Stage::topk(LogicalExpr::field("published_year"), 100, true),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_doc_ids!(result, ["pride", "gatsby"]);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_text_filter_single_term_conjunctive(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::filter(FilterExpr::text(TextExpr::terms(
+                    true,
+                    vec![Term {
+                        token: "love".to_string(),
+                        field: Some("summary".to_string()),
+                        weight: 1.0,
+                    }],
+                ))),
+                Stage::topk(LogicalExpr::field("published_year"), 100, true),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_doc_ids!(result, ["gatsby", "pride"]);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_text_filter_two_terms_disjunctive(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::filter(FilterExpr::text(TextExpr::terms(
+                    false,
+                    vec![
+                        Term {
+                            token: "LOVE".to_string(),
+                            field: Some("summary".to_string()),
+                            weight: 1.0,
+                        },
+                        Term {
+                            token: "ring".to_string(),
+                            field: Some("title".to_string()),
+                            weight: 1.0,
+                        },
+                    ],
+                ))),
+                Stage::topk(LogicalExpr::field("published_year"), 100, true),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_doc_ids!(result, ["pride", "gatsby", "lotr"]);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_text_filter_two_terms_conjunctive(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::filter(FilterExpr::text(TextExpr::terms(
+                    true,
+                    vec![
+                        Term {
+                            token: "LOVE".to_string(),
+                            field: Some("summary".to_string()),
+                            weight: 1.0,
+                        },
+                        Term {
+                            token: "class".to_string(),
+                            field: Some("summary".to_string()),
+                            weight: 1.0,
+                        },
+                    ],
+                ))),
+                Stage::topk(LogicalExpr::field("published_year"), 100, true),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_doc_ids!(result, ["pride"]);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_text_filter_stop_word(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::filter(FilterExpr::text(TextExpr::terms(
+                    true,
+                    vec![Term {
+                        token: "the".to_string(),
+                        field: None,
+                        weight: 1.0,
+                    }],
+                ))),
+                Stage::topk(LogicalExpr::field("published_year"), 100, true),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_doc_ids!(result, Vec::<String>::new());
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_select_bm25_without_text_queries(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let err = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::select(HashMap::from([(
+                    "bm25_score".to_string(),
+                    SelectExpr::function(FunctionExpr::bm25_score()),
+                )])),
+                Stage::filter(FilterExpr::logical(LogicalExpr::eq(
+                    LogicalExpr::field("_id"),
+                    LogicalExpr::literal("pride".into()),
+                ))),
+                Stage::topk(LogicalExpr::field("bm25_score"), 100, true),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect_err("should have failed");
+
+    assert!(matches!(err, Error::InvalidArgument(_)));
+}

--- a/topk-rs/tests/test_query_unified.rs
+++ b/topk-rs/tests/test_query_unified.rs
@@ -1,0 +1,77 @@
+use std::collections::{HashMap, HashSet};
+use test_context::test_context;
+use topk_protos::v1::data::{
+    stage::{filter_stage::FilterExpr, select_stage::SelectExpr},
+    text_expr::Term,
+    FunctionExpr, LogicalExpr, Query, Stage, TextExpr, Vector,
+};
+
+mod utils;
+use utils::dataset;
+use utils::ProjectTestContext;
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_unified(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::select(HashMap::from([
+                    (
+                        "summary_distance".to_string(),
+                        SelectExpr::function(FunctionExpr::vector_distance(
+                            "summary_embedding".to_string(),
+                            Vector::float(vec![2.0; 16]),
+                        )),
+                    ),
+                    (
+                        "bm25_score".to_string(),
+                        SelectExpr::function(FunctionExpr::bm25_score()),
+                    ),
+                ])),
+                Stage::filter(FilterExpr::text(TextExpr::terms(
+                    false,
+                    vec![
+                        Term {
+                            token: "love".to_string(),
+                            field: None,
+                            weight: 30.0,
+                        },
+                        Term {
+                            token: "young".to_string(),
+                            field: None,
+                            weight: 10.0,
+                        },
+                    ],
+                ))),
+                Stage::topk(
+                    LogicalExpr::add(
+                        LogicalExpr::field("bm25_score"),
+                        LogicalExpr::mul(
+                            LogicalExpr::field("summary_distance"),
+                            LogicalExpr::literal((100 as u32).into()),
+                        ),
+                    ),
+                    2,
+                    true,
+                ),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert!(result.len() == 2);
+    assert_eq!(
+        result
+            .into_iter()
+            .map(|d| d.id().unwrap().to_string())
+            .collect::<HashSet<_>>(),
+        ["mockingbird".into(), "pride".into()].into()
+    );
+}

--- a/topk-rs/tests/test_query_validation.rs
+++ b/topk-rs/tests/test_query_validation.rs
@@ -1,0 +1,130 @@
+use test_context::test_context;
+use topk_protos::v1::data::{LogicalExpr, Query, Stage, Value};
+use topk_protos::{doc, schema};
+use topk_rs::Error;
+
+mod utils;
+use utils::dataset;
+use utils::ProjectTestContext;
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_topk_by_non_primitive(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let err = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![Stage::topk(LogicalExpr::field("title"), 3, true)]),
+            None,
+            None,
+        )
+        .await
+        .expect_err("should have failed");
+
+    assert!(
+        matches!(err, Error::InvalidArgument(s) if s == "Input to SortWithLimit must produce primitive type, not String")
+    );
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_topk_by_non_existing(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let err = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![Stage::topk(
+                LogicalExpr::field("non_existing_field"),
+                3,
+                true,
+            )]),
+            None,
+            None,
+        )
+        .await
+        .expect_err("should have failed");
+
+    assert!(matches!(
+        err,
+        Error::InvalidArgument(s) if s == "Input to SortWithLimit must produce primitive type, not Null"
+    ));
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_topk_limit_zero(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let err = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![Stage::topk(
+                LogicalExpr::field("published_year"),
+                0,
+                true,
+            )]),
+            None,
+            None,
+        )
+        .await
+        .expect_err("should have failed");
+
+    assert!(matches!(
+        err,
+        Error::InvalidArgument(s) if s == "Invalid argument: TopK k must be > 0"
+    ));
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_union_u32_and_binary(ctx: &mut ProjectTestContext) {
+    // create collection
+    let collection = ctx
+        .client
+        .collections()
+        .create(ctx.wrap("test"), schema!())
+        .await
+        .expect("could not create collection");
+
+    // upsert documents
+    let lsn = ctx
+        .client
+        .collection(&collection.name)
+        .upsert(vec![
+            doc!("_id" => "1", "num" => (1 as u32)),
+            doc!("_id" => "11", "num" => Value::binary(vec![1, 2, 3])),
+        ])
+        .await
+        .expect("upsert failed");
+
+    // wait for writes to be flushed
+    let _ = ctx
+        .client
+        .collection(&collection.name)
+        .query(Query::new(vec![Stage::count()]), Some(lsn), None)
+        .await
+        .expect("could not query");
+
+    let err = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![Stage::topk(LogicalExpr::field("num"), 100, true)]),
+            None,
+            None,
+        )
+        .await
+        .expect_err("should have failed");
+
+    println!("err: {:?}", err);
+
+    assert!(matches!(
+        err,
+        Error::InvalidArgument(s) if s == "Input to SortWithLimit must produce primitive type, not Union([Primitive(U32), Binary])"
+    ));
+}

--- a/topk-rs/tests/test_query_vector.rs
+++ b/topk-rs/tests/test_query_vector.rs
@@ -1,0 +1,144 @@
+use std::collections::HashMap;
+use test_context::test_context;
+use topk_protos::v1::data::{
+    stage::select_stage::SelectExpr, Document, FunctionExpr, LogicalExpr, Query, Stage, Vector,
+};
+
+mod utils;
+use utils::dataset;
+use utils::ProjectTestContext;
+
+fn is_sorted(result: &[Document], field: &str) -> bool {
+    result
+        .iter()
+        .map(|d| {
+            d.fields
+                .get(field)
+                .and_then(|v| v.as_f32())
+                .expect("missing sorting field")
+        })
+        .is_sorted()
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_vector_distance(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::select(HashMap::from([
+                    (
+                        "title".to_string(),
+                        SelectExpr::logical(LogicalExpr::field("title".to_string())),
+                    ),
+                    (
+                        "summary_distance".to_string(),
+                        SelectExpr::function(FunctionExpr::vector_distance(
+                            "summary_embedding".to_string(),
+                            Vector::float(vec![2.0; 16]),
+                        )),
+                    ),
+                ])),
+                Stage::topk(LogicalExpr::field("summary_distance"), 3, true),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert!(is_sorted(&result, "summary_distance"));
+    assert_fields!(&result, ["_id", "title", "summary_distance"]);
+    assert_doc_ids!(result, ["1984", "pride", "mockingbird"]);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_vector_distance_nullable(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::select(HashMap::from([(
+                    "summary_distance".to_string(),
+                    SelectExpr::function(FunctionExpr::vector_distance(
+                        "nullable_embedding".to_string(),
+                        Vector::float(vec![3.0; 16]),
+                    )),
+                )])),
+                Stage::topk(LogicalExpr::field("summary_distance"), 3, true),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert!(is_sorted(&result, "summary_distance"));
+    assert_doc_ids!(result, ["1984", "mockingbird", "catcher"]);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_vector_distance_u8_vector(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::select(HashMap::from([(
+                    "summary_distance".to_string(),
+                    SelectExpr::function(FunctionExpr::vector_distance(
+                        "scalar_embedding".to_string(),
+                        Vector::byte(vec![8; 16]),
+                    )),
+                )])),
+                Stage::topk(LogicalExpr::field("summary_distance"), 3, true),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert!(is_sorted(&result, "summary_distance"));
+    assert_doc_ids!(result, ["harry", "1984", "catcher"]);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_vector_distance_binary_vector(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::select(HashMap::from([(
+                    "summary_distance".to_string(),
+                    SelectExpr::function(FunctionExpr::vector_distance(
+                        "binary_embedding".to_string(),
+                        Vector::byte(vec![0, 1]),
+                    )),
+                )])),
+                Stage::topk(LogicalExpr::field("summary_distance"), 2, true),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert!(is_sorted(&result, "summary_distance"));
+    assert_doc_ids!(result, ["1984", "mockingbird"]);
+}

--- a/topk-rs/tests/test_semantic_index.rs
+++ b/topk-rs/tests/test_semantic_index.rs
@@ -1,0 +1,357 @@
+use std::collections::HashMap;
+use test_context::test_context;
+use topk_protos::{
+    doc, schema,
+    v1::{
+        control::FieldSpec,
+        data::{
+            stage::{filter_stage::FilterExpr, select_stage::SelectExpr},
+            text_expr::Term,
+            FunctionExpr, LogicalExpr, Query, Stage, TextExpr,
+        },
+    },
+};
+use topk_rs::Error;
+
+mod utils;
+use utils::dataset;
+use utils::ProjectTestContext;
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_semantic_index_schema(ctx: &mut ProjectTestContext) {
+    let collection = dataset::semantic::setup(ctx).await;
+
+    for (field, _) in collection.schema.iter() {
+        assert!(
+            !field.starts_with("_"),
+            "Schema contains reserved field: {}",
+            field
+        );
+    }
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_semantic_index_create_with_invalid_model(ctx: &mut ProjectTestContext) {
+    let schema = schema!(
+        "title" => FieldSpec::semantic(true, Some("definitely-does-not-exist".into()), None),
+    );
+
+    let err = ctx
+        .client
+        .collections()
+        .create(ctx.wrap("semantic"), schema)
+        .await
+        .expect_err("should not create collection");
+
+    assert!(matches!(err, Error::SchemaValidationError(_)));
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_semantic_index_write_docs(ctx: &mut ProjectTestContext) {
+    let collection = dataset::semantic::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(Query::new(vec![Stage::count()]), None, None)
+        .await
+        .expect("could not query");
+
+    assert_eq!(result, vec![doc!("_count" => 10_u64)]);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_semantic_index_query(ctx: &mut ProjectTestContext) {
+    let collection = dataset::semantic::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::select(HashMap::from([(
+                    "sim".to_string(),
+                    SelectExpr::function(FunctionExpr::semantic_similarity(
+                        "title".to_string(),
+                        "dummy".to_string(),
+                    )),
+                )])),
+                Stage::topk(LogicalExpr::field("sim"), 3, true),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_eq!(result.len(), 3);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_semantic_index_query_with_text_filter(ctx: &mut ProjectTestContext) {
+    let collection = dataset::semantic::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::select(HashMap::from([(
+                    "sim".to_string(),
+                    SelectExpr::function(FunctionExpr::semantic_similarity(
+                        "title".to_string(),
+                        "dummy".to_string(),
+                    )),
+                )])),
+                Stage::filter(FilterExpr::text(TextExpr::terms(
+                    true,
+                    vec![Term {
+                        token: "love".to_string(),
+                        field: Some("summary".to_string()),
+                        weight: 1.0,
+                    }],
+                ))),
+                Stage::topk(LogicalExpr::field("sim"), 3, true),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_doc_ids!(result, ["gatsby", "pride"]);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_semantic_index_query_with_missing_index(ctx: &mut ProjectTestContext) {
+    let collection = dataset::semantic::setup(ctx).await;
+
+    let err = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::select(HashMap::from([(
+                    "sim".to_string(),
+                    SelectExpr::function(FunctionExpr::semantic_similarity(
+                        "published_year".to_string(),
+                        "dummy".to_string(),
+                    )),
+                )])),
+                Stage::topk(LogicalExpr::field("sim"), 3, true),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect_err("should not query");
+
+    assert!(matches!(err, Error::InvalidArgument(_)));
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_semantic_index_query_multiple_fields(ctx: &mut ProjectTestContext) {
+    let collection = dataset::semantic::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::select(HashMap::from([
+                    (
+                        "title_sim".to_string(),
+                        SelectExpr::function(FunctionExpr::semantic_similarity(
+                            "title".to_string(),
+                            "dummy".to_string(),
+                        )),
+                    ),
+                    (
+                        "summary_sim".to_string(),
+                        SelectExpr::function(FunctionExpr::semantic_similarity(
+                            "summary".to_string(),
+                            "query".to_string(),
+                        )),
+                    ),
+                ])),
+                Stage::topk(
+                    LogicalExpr::add(
+                        LogicalExpr::field("title_sim"),
+                        LogicalExpr::field("summary_sim"),
+                    ),
+                    5,
+                    true,
+                ),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_eq!(result.len(), 5);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_semantic_index_query_and_rerank_with_missing_model(ctx: &mut ProjectTestContext) {
+    let collection = dataset::semantic::setup(ctx).await;
+
+    let err = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::select(HashMap::from([(
+                    "sim".to_string(),
+                    SelectExpr::function(FunctionExpr::semantic_similarity(
+                        "title".to_string(),
+                        "dummy".to_string(),
+                    )),
+                )])),
+                Stage::topk(LogicalExpr::field("sim"), 3, true),
+                Stage::rerank(Some("definitely-does-not-exist".into()), None, vec![], None),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect_err("should not query");
+
+    assert!(matches!(err, Error::InvalidArgument(_)));
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_semantic_index_query_and_rerank(ctx: &mut ProjectTestContext) {
+    let collection = dataset::semantic::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::select(HashMap::from([(
+                    "sim".to_string(),
+                    SelectExpr::function(FunctionExpr::semantic_similarity(
+                        "title".to_string(),
+                        "dummy".to_string(),
+                    )),
+                )])),
+                Stage::topk(LogicalExpr::field("sim"), 3, true),
+                Stage::rerank(Some("dummy".into()), None, vec![], None),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_eq!(result.len(), 3);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_semantic_index_query_and_rerank_multiple_semantic_sim_explicit(
+    ctx: &mut ProjectTestContext,
+) {
+    let collection = dataset::semantic::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::select(HashMap::from([
+                    (
+                        "title_sim".to_string(),
+                        SelectExpr::function(FunctionExpr::semantic_similarity(
+                            "title".to_string(),
+                            "dummy".to_string(),
+                        )),
+                    ),
+                    (
+                        "summary_sim".to_string(),
+                        SelectExpr::function(FunctionExpr::semantic_similarity(
+                            "summary".to_string(),
+                            "query".to_string(),
+                        )),
+                    ),
+                ])),
+                Stage::topk(
+                    LogicalExpr::add(
+                        LogicalExpr::field("title_sim"),
+                        LogicalExpr::field("summary_sim"),
+                    ),
+                    5,
+                    true,
+                ),
+                Stage::rerank(
+                    Some("dummy".into()),
+                    Some("query string".into()),
+                    vec!["title".to_string(), "summary".to_string()],
+                    None,
+                ),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_eq!(result.len(), 5);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_semantic_index_query_and_rerank_multiple_semantic_sim_implicit(
+    ctx: &mut ProjectTestContext,
+) {
+    let collection = dataset::semantic::setup(ctx).await;
+
+    let err = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            Query::new(vec![
+                Stage::select(HashMap::from([
+                    (
+                        "title_sim".to_string(),
+                        SelectExpr::function(FunctionExpr::semantic_similarity(
+                            "title".to_string(),
+                            "dummy".to_string(),
+                        )),
+                    ),
+                    (
+                        "summary_sim".to_string(),
+                        SelectExpr::function(FunctionExpr::semantic_similarity(
+                            "summary".to_string(),
+                            "query".to_string(),
+                        )),
+                    ),
+                ])),
+                Stage::topk(
+                    LogicalExpr::add(
+                        LogicalExpr::field("title_sim"),
+                        LogicalExpr::field("summary_sim"),
+                    ),
+                    5,
+                    true,
+                ),
+                Stage::rerank(Some("dummy".into()), None, vec![], None),
+            ]),
+            None,
+            None,
+        )
+        .await
+        .expect_err("should not query");
+
+    assert!(matches!(err, Error::InvalidArgument(_)));
+}

--- a/topk-rs/tests/test_upsert.rs
+++ b/topk-rs/tests/test_upsert.rs
@@ -1,0 +1,237 @@
+use std::collections::HashMap;
+use test_context::test_context;
+use topk_protos::doc;
+use topk_protos::v1::{
+    control::{field_type::DataType, FieldSpec, FieldType, FieldTypeText},
+    data::Document,
+};
+use topk_rs::{Error, ValidationError, ValidationErrorBag};
+
+mod utils;
+use utils::ProjectTestContext;
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_upsert_to_non_existent_collection(ctx: &mut ProjectTestContext) {
+    let err = ctx
+        .client
+        .collection("missing")
+        .upsert(vec![doc!("_id" => "one")])
+        .await
+        .expect_err("should not be able to upsert document to non-existent collection");
+
+    assert!(matches!(err, Error::CollectionNotFound));
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_upsert_basic(ctx: &mut ProjectTestContext) {
+    let collection = ctx
+        .client
+        .collections()
+        .create(ctx.wrap("test"), HashMap::default())
+        .await
+        .expect("could not create collection");
+
+    let lsn = ctx
+        .client
+        .collection(&collection.name)
+        .upsert(vec![doc!("_id" => "one")])
+        .await
+        .expect("could not upsert document");
+
+    assert_eq!(lsn, 1);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_upsert_batch(ctx: &mut ProjectTestContext) {
+    let collection = ctx
+        .client
+        .collections()
+        .create(ctx.wrap("test"), HashMap::default())
+        .await
+        .expect("could not create collection");
+
+    let lsn = ctx
+        .client
+        .collection(collection.name)
+        .upsert(vec![doc!("_id" => "one"), doc!("_id" => "two")])
+        .await
+        .expect("could not upsert document");
+
+    assert_eq!(lsn, 1);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_upsert_sequential(ctx: &mut ProjectTestContext) {
+    let collection = ctx
+        .client
+        .collections()
+        .create(ctx.wrap("test"), HashMap::default())
+        .await
+        .expect("could not create collection");
+
+    let lsn = ctx
+        .client
+        .collection(&collection.name)
+        .upsert(vec![doc!("_id" => "one")])
+        .await
+        .expect("could not upsert document");
+    assert_eq!(lsn, 1);
+
+    let lsn = ctx
+        .client
+        .collection(&collection.name)
+        .upsert(vec![doc!("_id" => "two")])
+        .await
+        .expect("could not upsert document");
+    assert_eq!(lsn, 2);
+
+    let lsn = ctx
+        .client
+        .collection(&collection.name)
+        .upsert(vec![doc!("_id" => "three")])
+        .await
+        .expect("could not upsert document");
+    assert_eq!(lsn, 3);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_upsert_no_documents(ctx: &mut ProjectTestContext) {
+    let collection = ctx
+        .client
+        .collections()
+        .create(ctx.wrap("test"), HashMap::default())
+        .await
+        .expect("could not create collection");
+
+    let err = ctx
+        .client
+        .collection(collection.name)
+        .upsert(vec![])
+        .await
+        .expect_err("should not be able to upsert invalid document");
+
+    assert!(
+        matches!(err, Error::DocumentValidationError(ref s) if s == &ValidationErrorBag::from(vec![ValidationError::NoDocuments {}])),
+        "got error: {:?}",
+        err
+    );
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_upsert_invalid_document(ctx: &mut ProjectTestContext) {
+    let collection = ctx
+        .client
+        .collections()
+        .create(ctx.wrap("test"), HashMap::default())
+        .await
+        .expect("could not create collection");
+
+    let err = ctx
+        .client
+        .collection(collection.name)
+        .upsert(vec![Document::default()])
+        .await
+        .expect_err("should not be able to upsert invalid document");
+
+    assert!(
+        matches!(
+            err,
+            Error::DocumentValidationError(ref s) if s == &ValidationErrorBag::from(vec![ValidationError::MissingId { doc_offset: 0 } ])
+        ),
+        "got error: {:?}",
+        err
+    );
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_upsert_schema_validation(ctx: &mut ProjectTestContext) {
+    let collection = ctx
+        .client
+        .collections()
+        .create(
+            ctx.wrap("test"),
+            HashMap::from_iter([(
+                "name".to_string(),
+                FieldSpec {
+                    data_type: Some(FieldType {
+                        data_type: Some(DataType::Text(FieldTypeText {})),
+                    }),
+                    required: true,
+                    index: None,
+                },
+            )]),
+        )
+        .await
+        .expect("could not create collection");
+
+    let err = ctx
+        .client
+        .collection(collection.name)
+        .upsert(vec![doc!("_id" => "one")])
+        .await
+        .expect_err("should not be able to upsert invalid document");
+
+    assert!(
+        matches!(
+            err,
+            Error::DocumentValidationError(ref s) if s == &ValidationErrorBag::from(vec![ValidationError::MissingField {
+                field: "name".to_string(),
+                doc_id: "one".to_string(),
+            }])
+        ),
+        "got error: {:?}",
+        err
+    );
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_upsert_request_too_large(ctx: &mut ProjectTestContext) {
+    let collection_name = ctx.wrap("test");
+    ctx.client
+        .collections()
+        .create(
+            collection_name.clone(),
+            HashMap::from_iter([(
+                "name".to_string(),
+                FieldSpec {
+                    data_type: Some(FieldType {
+                        data_type: Some(DataType::Text(FieldTypeText {})),
+                    }),
+                    required: true,
+                    index: None,
+                },
+            )]),
+        )
+        .await
+        .expect("could not create collection");
+
+    // 8MB should be OK
+    let docs = (0..8)
+        .map(|i| doc!("_id" => format!("id-{}", i), "name" => format!("{}", "x".repeat(1024 * 1024))))
+        .collect::<Vec<_>>();
+    ctx.client
+        .collection(collection_name.clone())
+        .upsert(docs)
+        .await
+        .expect("should have passed");
+
+    // 16MB is too much
+    let docs = (0..16)
+        .map(|i| doc!("_id" => format!("id-{}", i), "name" => format!("{}", "x".repeat(1024 * 1024))))
+        .collect::<Vec<_>>();
+    let err = ctx
+        .client
+        .collection(collection_name)
+        .upsert(docs)
+        .await
+        .expect_err("should not be able to upsert invalid document");
+    assert!(matches!(err, Error::Unexpected(ref s) if s.code() == tonic::Code::OutOfRange));
+}

--- a/topk-rs/tests/utils/dataset/books.rs
+++ b/topk-rs/tests/utils/dataset/books.rs
@@ -1,0 +1,134 @@
+use crate::utils::ProjectTestContext;
+use std::collections::HashMap;
+use topk_protos::v1::{
+    control::{Collection, FieldSpec, KeywordIndexType, VectorDistanceMetric},
+    data::{Document, Query, Stage, Value},
+};
+use topk_protos::{doc, schema};
+
+#[allow(dead_code)]
+pub async fn setup(ctx: &mut ProjectTestContext) -> Collection {
+    let collection = ctx
+        .client
+        .collections()
+        .create(ctx.wrap("books"), schema())
+        .await
+        .expect("could not create collection");
+
+    let lsn = ctx
+        .client
+        .collection(&collection.name)
+        .upsert(docs())
+        .await
+        .expect("upsert failed");
+
+    let _ = ctx
+        .client
+        .collection(&collection.name)
+        .query(Query::new(vec![Stage::count()]), Some(lsn), None)
+        .await
+        .expect("could not query");
+
+    collection
+}
+
+#[allow(dead_code)]
+pub fn schema() -> HashMap<String, FieldSpec> {
+    schema!(
+        "title" => FieldSpec::text(true, Some(KeywordIndexType::Text)),
+        "published_year" => FieldSpec::integer(true),
+        "summary" => FieldSpec::text(true, Some(KeywordIndexType::Text)),
+        "summary_embedding" => FieldSpec::f32_vector(16, true, VectorDistanceMetric::Euclidean),
+        "nullable_embedding" => FieldSpec::f32_vector(16, false, VectorDistanceMetric::Euclidean),
+        "scalar_embedding" => FieldSpec::u8_vector(16, false, VectorDistanceMetric::Euclidean),
+        "binary_embedding" => FieldSpec::binary_vector(2, false, VectorDistanceMetric::Hamming),
+    )
+}
+
+#[allow(dead_code)]
+pub fn docs() -> Vec<Document> {
+    vec![
+        doc!(
+            "_id" => "mockingbird",
+            "title" => "To Kill a Mockingbird",
+            "published_year" => 1960 as u32,
+            "summary" => "A young girl confronts racial injustice in the Deep South through the eyes of her lawyer father.",
+            "summary_embedding" => vec![1.0; 16],
+            "nullable_embedding" => vec![1.0; 16],
+            "scalar_embedding" => Value::byte_vector(vec![1; 16]),
+            "binary_embedding" => Value::byte_vector(vec![0, 1]),
+        ),
+        doc!(
+            "_id" => "1984",
+            "title" => "1984",
+            "published_year" => 1949 as u32,
+            "summary" => "A totalitarian regime uses surveillance and mind control to oppress its citizens.",
+            "summary_embedding" => vec![2.0; 16],
+            "nullable_embedding" => vec![2.0; 16],
+            "scalar_embedding" => Value::byte_vector(vec![2; 16]),
+            "binary_embedding" => Value::byte_vector(vec![0, 3]),
+        ),
+        doc!(
+            "_id" => "pride",
+            "title" => "Pride and Prejudice",
+            "published_year" => 1813 as u32,
+            "summary" => "A witty exploration of love, social class, and marriage in 19th-century England.",
+            "summary_embedding" => vec![3.0; 16],
+        ),
+        doc!(
+            "_id" => "gatsby",
+            "title" => "The Great Gatsby",
+            "published_year" => 1925 as u32,
+            "summary" => "A mysterious millionaire navigates love and wealth in the Roaring Twenties.",
+            "summary_embedding" => vec![4.0; 16],
+        ),
+        doc!(
+            "_id" => "catcher",
+            "title" => "The Catcher in the Rye",
+            "published_year" => 1951 as u32,
+            "summary" => "A rebellious teenager struggles with alienation and identity in mid-20th-century America.",
+            "summary_embedding" => vec![5.0; 16],
+            "nullable_embedding" => vec![5.0; 16],
+            "scalar_embedding" => Value::byte_vector(vec![5; 16]),
+            "binary_embedding" => Value::byte_vector(vec![0, 7]),
+        ),
+        doc!(
+            "_id" => "moby",
+            "title" => "Moby-Dick",
+            "published_year" => 1851 as u32,
+            "summary" => "A sailor's obsessive quest to hunt a great white whale leads to tragic consequences.",
+            "summary_embedding" => vec![6.0; 16],
+        ),
+        doc!(
+            "_id" => "hobbit",
+            "title" => "The Hobbit",
+            "published_year" => 1937 as u32,
+            "summary" => "A reluctant hobbit embarks on a quest to help a group of dwarves reclaim their mountain home.",
+            "summary_embedding" => vec![7.0; 16],
+        ),
+        doc!(
+            "_id" => "harry",
+            "title" => "Harry Potter and the Sorcerer's Stone",
+            "published_year" => 1997 as u32,
+            "summary" => "A young wizard discovers his magical heritage and attends a school for witchcraft and wizardry.",
+            "summary_embedding" => vec![8.0; 16],
+            "nullable_embedding" => vec![8.0; 16],
+            "scalar_embedding" => Value::byte_vector(vec![8; 16]),
+            "binary_embedding" => Value::byte_vector(vec![0, 15]),
+        ),
+        doc!(
+            "_id" => "lotr",
+            "title" => "The Lord of the Rings: The Fellowship of the Ring",
+            "published_year" => 1954 as u32,
+            "summary" => "A group of unlikely heroes sets out to destroy a powerful, evil ring.",
+            "summary_embedding" => vec![9.0; 16],
+        ),
+        doc!(
+            "_id" => "alchemist",
+            "title" => "The Alchemist",
+            "published_year" => 1988 as u32,
+            "summary" => "A shepherd boy journeys to fulfill his destiny and discover the meaning of life.",
+            "summary_embedding" => vec![10.0; 16],
+        ),
+    ]
+}

--- a/topk-rs/tests/utils/dataset/mod.rs
+++ b/topk-rs/tests/utils/dataset/mod.rs
@@ -1,0 +1,2 @@
+pub mod books;
+pub mod semantic;

--- a/topk-rs/tests/utils/dataset/semantic.rs
+++ b/topk-rs/tests/utils/dataset/semantic.rs
@@ -1,0 +1,107 @@
+use crate::utils::ProjectTestContext;
+use std::collections::HashMap;
+use topk_protos::v1::{
+    control::{Collection, FieldSpec},
+    data::{Document, Query, Stage},
+};
+use topk_protos::{doc, schema};
+
+#[allow(dead_code)]
+pub async fn setup(ctx: &mut ProjectTestContext) -> Collection {
+    let collection = ctx
+        .client
+        .collections()
+        .create(ctx.wrap("semantic"), schema())
+        .await
+        .expect("could not create collection");
+
+    let lsn = ctx
+        .client
+        .collection(&collection.name)
+        .upsert(docs())
+        .await
+        .expect("upsert failed");
+
+    let _ = ctx
+        .client
+        .collection(&collection.name)
+        .query(Query::new(vec![Stage::count()]), Some(lsn), None)
+        .await
+        .expect("could not query");
+
+    collection
+}
+
+#[allow(dead_code)]
+pub fn schema() -> HashMap<String, FieldSpec> {
+    schema!(
+        "title" => FieldSpec::semantic(true, Some("dummy".into()), None),
+        "summary" => FieldSpec::semantic(false, Some("dummy".into()), None),
+    )
+}
+
+#[allow(dead_code)]
+pub fn docs() -> Vec<Document> {
+    vec![
+        doc!(
+            "_id" => "mockingbird",
+            "title" => "To Kill a Mockingbird",
+            "published_year" => 1960 as u32,
+            "summary" => "A young girl confronts racial injustice in the Deep South through the eyes of her lawyer father.",
+        ),
+        doc!(
+            "_id" => "1984",
+            "title" => "1984",
+            "published_year" => 1949 as u32,
+            "summary" => "A totalitarian regime uses surveillance and mind control to oppress its citizens.",
+        ),
+        doc!(
+            "_id" => "pride",
+            "title" => "Pride and Prejudice",
+            "published_year" => 1813 as u32,
+            "summary" => "A witty exploration of love, social class, and marriage in 19th-century England.",
+        ),
+        doc!(
+            "_id" => "gatsby",
+            "title" => "The Great Gatsby",
+            "published_year" => 1925 as u32,
+            "summary" => "A mysterious millionaire navigates love and wealth in the Roaring Twenties.",
+        ),
+        doc!(
+            "_id" => "catcher",
+            "title" => "The Catcher in the Rye",
+            "published_year" => 1951 as u32,
+            "summary" => "A rebellious teenager struggles with alienation and identity in mid-20th-century America.",
+        ),
+        doc!(
+            "_id" => "moby",
+            "title" => "Moby-Dick",
+            "published_year" => 1851 as u32,
+            "summary" => "A sailor's obsessive quest to hunt a great white whale leads to tragic consequences.",
+        ),
+        doc!(
+            "_id" => "hobbit",
+            "title" => "The Hobbit",
+            "published_year" => 1937 as u32,
+            "summary" => "A reluctant hobbit embarks on a quest to help a group of dwarves reclaim their mountain home.",
+        ),
+        doc!(
+            "_id" => "harry",
+            "title" => "Harry Potter and the Sorcerer's Stone",
+            "published_year" => 1997 as u32,
+            "summary" => "A young wizard discovers his magical heritage and attends a school for witchcraft and wizardry.",
+        ),
+        doc!(
+            "_id" => "lotr",
+            "title" => "The Lord of the Rings: The Fellowship of the Ring",
+            "published_year" => 1954 as u32,
+            "summary" => "A group of unlikely heroes sets out to destroy a powerful, evil ring.",
+        ),
+        doc!(
+            "_id" => "alchemist",
+            "title" => "The Alchemist",
+            "published_year" => 1988 as u32,
+            "summary" => "A shepherd boy journeys to fulfill his destiny and discover the meaning of life.",
+        ),
+    ]
+}

--- a/topk-rs/tests/utils/mod.rs
+++ b/topk-rs/tests/utils/mod.rs
@@ -1,0 +1,48 @@
+pub mod dataset;
+
+mod test_context;
+pub use test_context::project::ProjectTestContext;
+
+#[macro_export]
+macro_rules! assert_doc_ids {
+    ($docs:expr, $expected:expr) => {{
+        let ids = $docs
+            .into_iter()
+            .map(|d| d.id().unwrap().to_string())
+            .collect::<std::collections::HashSet<_>>();
+
+        let expected = $expected
+            .into_iter()
+            .map(|s| s.into())
+            .collect::<std::collections::HashSet<_>>();
+
+        assert!(
+            ids == expected,
+            "actual: {:?}, expected: {:?}",
+            ids,
+            expected
+        );
+    }};
+}
+
+#[macro_export]
+macro_rules! assert_fields {
+    ($docs:expr, $expected:expr) => {{
+        let fields = $docs
+            .into_iter()
+            .flat_map(|d| d.fields.keys().map(|k| k.as_str()))
+            .collect::<std::collections::HashSet<_>>();
+
+        let expected = $expected
+            .into_iter()
+            .map(|s| s.into())
+            .collect::<std::collections::HashSet<_>>();
+
+        assert!(
+            fields == expected,
+            "actual: {:?}, expected: {:?}",
+            fields,
+            expected
+        );
+    }};
+}

--- a/topk-rs/tests/utils/test_context/mod.rs
+++ b/topk-rs/tests/utils/test_context/mod.rs
@@ -1,0 +1,1 @@
+pub mod project;

--- a/topk-rs/tests/utils/test_context/project.rs
+++ b/topk-rs/tests/utils/test_context/project.rs
@@ -1,0 +1,51 @@
+use test_context::AsyncTestContext;
+use topk_rs::{Client, ClientConfig};
+use uuid::Uuid;
+
+pub struct ProjectTestContext {
+    pub client: Client,
+    pub scope: String,
+}
+
+impl ProjectTestContext {
+    pub fn wrap(&self, name: &str) -> String {
+        format!("{}-{}", self.scope, name)
+    }
+}
+
+impl AsyncTestContext for ProjectTestContext {
+    async fn setup() -> Self {
+        let scope = format!("scope-{}", Uuid::new_v4());
+
+        let host = std::env::var("TOPK_HOST").unwrap_or("topk.io".to_string());
+        let region = std::env::var("TOPK_REGION").unwrap_or("elastica".to_string());
+        let api_key = std::env::var("TOPK_API_KEY").expect("TOPK_API_KEY not set");
+        let https = std::env::var("TOPK_HTTPS").unwrap_or("true".to_string()) == "true";
+
+        let client = Client::new(
+            ClientConfig::new(api_key, region)
+                .with_host(host)
+                .with_https(https),
+        );
+
+        Self { client, scope }
+    }
+
+    async fn teardown(self) {
+        let client = self.client.collections();
+        let collections = client
+            .list()
+            .await
+            .expect("Failed to list collections on teardown");
+        for collection in collections {
+            if collection.name.starts_with(&self.scope) {
+                println!("Deleting collection: {}", collection.name);
+                let res = client.delete(&collection.name).await;
+
+                if let Err(e) = res {
+                    println!("Failed to delete collection {}: {}", collection.name, e);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR open-sources our e2e test suite. Also, add `test-rs` earthly target and gh action pipeline