### PR TITLE
fluent query builder for `topk-rs`

### DIFF
--- a/topk-protos/src/data/v1/query_ext.rs
+++ b/topk-protos/src/data/v1/query_ext.rs
@@ -28,7 +28,7 @@ impl Stage {
         }
     }
 
-    pub fn topk(expr: LogicalExpr, k: u64, asc: bool) -> Self {
+    pub fn top_k(expr: LogicalExpr, k: u64, asc: bool) -> Self {
         Stage {
             stage: Some(stage::Stage::TopK(stage::TopKStage {
                 expr: Some(expr),

--- a/topk-py/src/data/expr_binary.rs
+++ b/topk-py/src/data/expr_binary.rs
@@ -23,24 +23,22 @@ pub enum BinaryOperator {
     Rem,
 }
 
-impl Into<topk_protos::v1::data::logical_expr::binary_op::Op> for BinaryOperator {
-    fn into(self) -> topk_protos::v1::data::logical_expr::binary_op::Op {
+impl Into<topk_rs::data::expr_binary::BinaryOperator> for BinaryOperator {
+    fn into(self) -> topk_rs::data::expr_binary::BinaryOperator {
         match self {
-            BinaryOperator::Eq => topk_protos::v1::data::logical_expr::binary_op::Op::Eq,
-            BinaryOperator::NotEq => topk_protos::v1::data::logical_expr::binary_op::Op::Neq,
-            BinaryOperator::Lt => topk_protos::v1::data::logical_expr::binary_op::Op::Lt,
-            BinaryOperator::LtEq => topk_protos::v1::data::logical_expr::binary_op::Op::Lte,
-            BinaryOperator::Gt => topk_protos::v1::data::logical_expr::binary_op::Op::Gt,
-            BinaryOperator::GtEq => topk_protos::v1::data::logical_expr::binary_op::Op::Gte,
-            BinaryOperator::StartsWith => {
-                topk_protos::v1::data::logical_expr::binary_op::Op::StartsWith
-            }
-            BinaryOperator::Add => topk_protos::v1::data::logical_expr::binary_op::Op::Add,
-            BinaryOperator::Sub => topk_protos::v1::data::logical_expr::binary_op::Op::Sub,
-            BinaryOperator::Mul => topk_protos::v1::data::logical_expr::binary_op::Op::Mul,
-            BinaryOperator::Div => topk_protos::v1::data::logical_expr::binary_op::Op::Div,
-            BinaryOperator::And => topk_protos::v1::data::logical_expr::binary_op::Op::And,
-            BinaryOperator::Or => topk_protos::v1::data::logical_expr::binary_op::Op::Or,
+            BinaryOperator::Eq => topk_rs::data::expr_binary::BinaryOperator::Eq,
+            BinaryOperator::NotEq => topk_rs::data::expr_binary::BinaryOperator::NotEq,
+            BinaryOperator::Lt => topk_rs::data::expr_binary::BinaryOperator::Lt,
+            BinaryOperator::LtEq => topk_rs::data::expr_binary::BinaryOperator::LtEq,
+            BinaryOperator::Gt => topk_rs::data::expr_binary::BinaryOperator::Gt,
+            BinaryOperator::GtEq => topk_rs::data::expr_binary::BinaryOperator::GtEq,
+            BinaryOperator::StartsWith => topk_rs::data::expr_binary::BinaryOperator::StartsWith,
+            BinaryOperator::Add => topk_rs::data::expr_binary::BinaryOperator::Add,
+            BinaryOperator::Sub => topk_rs::data::expr_binary::BinaryOperator::Sub,
+            BinaryOperator::Mul => topk_rs::data::expr_binary::BinaryOperator::Mul,
+            BinaryOperator::Div => topk_rs::data::expr_binary::BinaryOperator::Div,
+            BinaryOperator::And => topk_rs::data::expr_binary::BinaryOperator::And,
+            BinaryOperator::Or => topk_rs::data::expr_binary::BinaryOperator::Or,
             BinaryOperator::Xor => unreachable!("Xor is not supported"),
             BinaryOperator::Rem => unreachable!("Rem is not supported"),
         }

--- a/topk-py/src/data/expr_unary.rs
+++ b/topk-py/src/data/expr_unary.rs
@@ -8,14 +8,12 @@ pub enum UnaryOperator {
     IsNotNull,
 }
 
-impl Into<topk_protos::v1::data::logical_expr::unary_op::Op> for UnaryOperator {
-    fn into(self) -> topk_protos::v1::data::logical_expr::unary_op::Op {
+impl Into<topk_rs::data::expr_unary::UnaryOperator> for UnaryOperator {
+    fn into(self) -> topk_rs::data::expr_unary::UnaryOperator {
         match self {
-            UnaryOperator::Not => topk_protos::v1::data::logical_expr::unary_op::Op::Not,
-            UnaryOperator::IsNull => topk_protos::v1::data::logical_expr::unary_op::Op::IsNull,
-            UnaryOperator::IsNotNull => {
-                topk_protos::v1::data::logical_expr::unary_op::Op::IsNotNull
-            }
+            UnaryOperator::Not => topk_rs::data::expr_unary::UnaryOperator::Not,
+            UnaryOperator::IsNull => topk_rs::data::expr_unary::UnaryOperator::IsNull,
+            UnaryOperator::IsNotNull => topk_rs::data::expr_unary::UnaryOperator::IsNotNull,
         }
     }
 }

--- a/topk-py/src/data/filter_expr.rs
+++ b/topk-py/src/data/filter_expr.rs
@@ -1,41 +1,38 @@
-use super::{logical_expr::LogicalExpression, text_expr::TextExpression};
+use super::{logical_expr::LogicalExpr, text_expr::TextExpr};
 use pyo3::prelude::*;
-use topk_protos::v1::data;
 
 #[pyclass]
 #[derive(Debug, Clone)]
-pub enum FilterExpression {
-    Logical(LogicalExpression),
-    Text(TextExpression),
+pub enum FilterExpr {
+    Logical(LogicalExpr),
+    Text(TextExpr),
 }
 
-impl Into<data::stage::filter_stage::FilterExpr> for FilterExpression {
-    fn into(self) -> data::stage::filter_stage::FilterExpr {
+impl Into<topk_rs::data::filter_expr::FilterExpr> for FilterExpr {
+    fn into(self) -> topk_rs::data::filter_expr::FilterExpr {
         match self {
-            FilterExpression::Logical(expr) => {
-                data::stage::filter_stage::FilterExpr::logical(expr.into())
+            FilterExpr::Logical(expr) => {
+                topk_rs::data::filter_expr::FilterExpr::Logical(expr.into())
             }
-            FilterExpression::Text(expr) => {
-                data::stage::filter_stage::FilterExpr::text(expr.into())
-            }
+            FilterExpr::Text(expr) => topk_rs::data::filter_expr::FilterExpr::Text(expr.into()),
         }
     }
 }
 
 #[derive(Debug, Clone, FromPyObject)]
-pub enum FilterExpressionUnion {
+pub enum FilterExprUnion {
     #[pyo3(transparent)]
-    Logical(LogicalExpression),
+    Logical(LogicalExpr),
 
     #[pyo3(transparent)]
-    Text(TextExpression),
+    Text(TextExpr),
 }
 
-impl Into<FilterExpression> for FilterExpressionUnion {
-    fn into(self) -> FilterExpression {
+impl Into<FilterExpr> for FilterExprUnion {
+    fn into(self) -> FilterExpr {
         match self {
-            FilterExpressionUnion::Logical(expr) => FilterExpression::Logical(expr),
-            FilterExpressionUnion::Text(expr) => FilterExpression::Text(expr),
+            FilterExprUnion::Logical(expr) => FilterExpr::Logical(expr),
+            FilterExprUnion::Text(expr) => FilterExpr::Text(expr),
         }
     }
 }

--- a/topk-py/src/data/flexible_expr.rs
+++ b/topk-py/src/data/flexible_expr.rs
@@ -1,4 +1,4 @@
-use super::{logical_expr::LogicalExpression, scalar::Scalar};
+use super::{logical_expr::LogicalExpr, scalar::Scalar};
 use pyo3::{
     exceptions::PyTypeError,
     prelude::*,
@@ -16,25 +16,25 @@ pub enum FlexibleExpr {
     Float(f64),
     Bool(bool),
     Null(Null),
-    Expr(LogicalExpression),
+    Expr(LogicalExpr),
 }
 
-impl Into<LogicalExpression> for FlexibleExpr {
-    fn into(self) -> LogicalExpression {
+impl Into<LogicalExpr> for FlexibleExpr {
+    fn into(self) -> LogicalExpr {
         match self {
-            FlexibleExpr::String(s) => LogicalExpression::Literal {
+            FlexibleExpr::String(s) => LogicalExpr::Literal {
                 value: Scalar::String(s),
             },
-            FlexibleExpr::Int(i) => LogicalExpression::Literal {
+            FlexibleExpr::Int(i) => LogicalExpr::Literal {
                 value: Scalar::Int(i),
             },
-            FlexibleExpr::Float(f) => LogicalExpression::Literal {
+            FlexibleExpr::Float(f) => LogicalExpr::Literal {
                 value: Scalar::Float(f),
             },
-            FlexibleExpr::Bool(b) => LogicalExpression::Literal {
+            FlexibleExpr::Bool(b) => LogicalExpr::Literal {
                 value: Scalar::Bool(b),
             },
-            FlexibleExpr::Null(_) => LogicalExpression::Null(),
+            FlexibleExpr::Null(_) => LogicalExpr::Null(),
             FlexibleExpr::Expr(e) => e,
         }
     }
@@ -54,7 +54,7 @@ impl<'py> FromPyObject<'py> for FlexibleExpr {
             Ok(FlexibleExpr::Bool(b.extract()?))
         } else if let Ok(_) = obj.downcast::<PyNone>() {
             Ok(FlexibleExpr::Null(Null))
-        } else if let Ok(e) = obj.downcast::<LogicalExpression>() {
+        } else if let Ok(e) = obj.downcast::<LogicalExpr>() {
             Ok(FlexibleExpr::Expr(e.get().clone()))
         } else {
             Err(PyTypeError::new_err(format!(
@@ -74,16 +74,16 @@ pub enum Numeric {
     Float(f64),
 
     #[pyo3(transparent)]
-    Expr(LogicalExpression),
+    Expr(LogicalExpr),
 }
 
-impl Into<LogicalExpression> for Numeric {
-    fn into(self) -> LogicalExpression {
+impl Into<LogicalExpr> for Numeric {
+    fn into(self) -> LogicalExpr {
         match self {
-            Numeric::Int(i) => LogicalExpression::Literal {
+            Numeric::Int(i) => LogicalExpr::Literal {
                 value: Scalar::Int(i),
             },
-            Numeric::Float(f) => LogicalExpression::Literal {
+            Numeric::Float(f) => LogicalExpr::Literal {
                 value: Scalar::Float(f),
             },
             Numeric::Expr(e) => e,
@@ -97,13 +97,13 @@ pub enum Boolish {
     Bool(bool),
 
     #[pyo3(transparent)]
-    Expr(LogicalExpression),
+    Expr(LogicalExpr),
 }
 
-impl Into<LogicalExpression> for Boolish {
-    fn into(self) -> LogicalExpression {
+impl Into<LogicalExpr> for Boolish {
+    fn into(self) -> LogicalExpr {
         match self {
-            Boolish::Bool(b) => LogicalExpression::Literal {
+            Boolish::Bool(b) => LogicalExpr::Literal {
                 value: Scalar::Bool(b),
             },
             Boolish::Expr(e) => e,
@@ -117,13 +117,13 @@ pub enum Stringy {
     String(String),
 
     #[pyo3(transparent)]
-    Expr(LogicalExpression),
+    Expr(LogicalExpr),
 }
 
-impl Into<LogicalExpression> for Stringy {
-    fn into(self) -> LogicalExpression {
+impl Into<LogicalExpr> for Stringy {
+    fn into(self) -> LogicalExpr {
         match self {
-            Stringy::String(s) => LogicalExpression::Literal {
+            Stringy::String(s) => LogicalExpr::Literal {
                 value: Scalar::String(s),
             },
             Stringy::Expr(e) => e,

--- a/topk-py/src/data/function_expr.rs
+++ b/topk-py/src/data/function_expr.rs
@@ -7,34 +7,37 @@ pub enum VectorQuery {
     U8(Vec<u8>),
 }
 
-impl Into<topk_protos::v1::data::Vector> for VectorQuery {
-    fn into(self) -> topk_protos::v1::data::Vector {
+impl Into<topk_rs::data::function_expr::Vector> for VectorQuery {
+    fn into(self) -> topk_rs::data::function_expr::Vector {
         match self {
-            VectorQuery::F32(values) => topk_protos::v1::data::Vector::float(values),
-            VectorQuery::U8(values) => topk_protos::v1::data::Vector::byte(values),
+            VectorQuery::F32(values) => topk_rs::data::function_expr::Vector::float(values),
+            VectorQuery::U8(values) => topk_rs::data::function_expr::Vector::byte(values),
         }
     }
 }
 
 #[pyclass]
 #[derive(Debug, Clone)]
-pub enum FunctionExpression {
+pub enum FunctionExpr {
     KeywordScore {},
     VectorScore { field: String, query: VectorQuery },
     SemanticSimilarity { field: String, query: String },
 }
 
-impl Into<topk_protos::v1::data::FunctionExpr> for FunctionExpression {
-    fn into(self) -> topk_protos::v1::data::FunctionExpr {
+impl Into<topk_rs::data::function_expr::FunctionExpr> for FunctionExpr {
+    fn into(self) -> topk_rs::data::function_expr::FunctionExpr {
         match self {
-            FunctionExpression::KeywordScore {} => {
-                topk_protos::v1::data::FunctionExpr::bm25_score()
+            FunctionExpr::KeywordScore {} => {
+                topk_rs::data::function_expr::FunctionExpr::KeywordScore {}
             }
-            FunctionExpression::VectorScore { field, query } => {
-                topk_protos::v1::data::FunctionExpr::vector_distance(field, query.into())
+            FunctionExpr::VectorScore { field, query } => {
+                topk_rs::data::function_expr::FunctionExpr::VectorScore {
+                    field,
+                    query: query.into(),
+                }
             }
-            FunctionExpression::SemanticSimilarity { field, query } => {
-                topk_protos::v1::data::FunctionExpr::semantic_similarity(field, query)
+            FunctionExpr::SemanticSimilarity { field, query } => {
+                topk_rs::data::function_expr::FunctionExpr::SemanticSimilarity { field, query }
             }
         }
     }

--- a/topk-py/src/data/logical_expr.rs
+++ b/topk-py/src/data/logical_expr.rs
@@ -8,7 +8,7 @@ use pyo3::prelude::*;
 
 #[pyclass]
 #[derive(Clone)]
-pub enum LogicalExpression {
+pub enum LogicalExpr {
     Null(),
     Field {
         name: String,
@@ -18,16 +18,16 @@ pub enum LogicalExpression {
     },
     Unary {
         op: UnaryOperator,
-        expr: Py<LogicalExpression>,
+        expr: Py<LogicalExpr>,
     },
     Binary {
-        left: Py<LogicalExpression>,
+        left: Py<LogicalExpr>,
         op: BinaryOperator,
-        right: Py<LogicalExpression>,
+        right: Py<LogicalExpr>,
     },
 }
 
-impl std::fmt::Debug for LogicalExpression {
+impl std::fmt::Debug for LogicalExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Null() => write!(f, "Null"),
@@ -49,31 +49,29 @@ impl std::fmt::Debug for LogicalExpression {
     }
 }
 
-impl PartialEq for LogicalExpression {
+impl PartialEq for LogicalExpr {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (LogicalExpression::Null(), LogicalExpression::Null()) => true,
-            (LogicalExpression::Field { name: l }, LogicalExpression::Field { name: r }) => l == r,
-            (LogicalExpression::Literal { value: l }, LogicalExpression::Literal { value: r }) => {
-                l == r
-            }
+            (LogicalExpr::Null(), LogicalExpr::Null()) => true,
+            (LogicalExpr::Field { name: l }, LogicalExpr::Field { name: r }) => l == r,
+            (LogicalExpr::Literal { value: l }, LogicalExpr::Literal { value: r }) => l == r,
             (
-                LogicalExpression::Unary {
+                LogicalExpr::Unary {
                     op: l,
                     expr: l_expr,
                 },
-                LogicalExpression::Unary {
+                LogicalExpr::Unary {
                     op: r,
                     expr: r_expr,
                 },
             ) => l == r && l_expr.get() == r_expr.get(),
             (
-                LogicalExpression::Binary {
+                LogicalExpr::Binary {
                     left: l,
                     op: l_op,
                     right: l_right,
                 },
-                LogicalExpression::Binary {
+                LogicalExpr::Binary {
                     left: r,
                     op: r_op,
                     right: r_right,
@@ -85,19 +83,19 @@ impl PartialEq for LogicalExpression {
 }
 
 #[pymethods]
-impl LogicalExpression {
+impl LogicalExpr {
     fn __repr__(&self) -> PyResult<String> {
         Ok(format!("{:?}", self))
     }
 
-    fn _expr_eq(&self, other: &LogicalExpression) -> bool {
+    fn _expr_eq(&self, other: &LogicalExpr) -> bool {
         self == other
     }
 
     // Comparison operators
 
     fn eq(&self, py: Python<'_>, other: FlexibleExpr) -> PyResult<Self> {
-        let expr: LogicalExpression = other.into();
+        let expr: LogicalExpr = other.into();
 
         Ok(Self::Binary {
             left: Py::new(py, self.clone())?,
@@ -111,7 +109,7 @@ impl LogicalExpression {
     }
 
     fn ne(&self, py: Python<'_>, other: FlexibleExpr) -> PyResult<Self> {
-        let expr: LogicalExpression = other.into();
+        let expr: LogicalExpr = other.into();
 
         Ok(Self::Binary {
             left: Py::new(py, self.clone())?,
@@ -125,7 +123,7 @@ impl LogicalExpression {
     }
 
     fn lt(&self, py: Python<'_>, other: Numeric) -> PyResult<Self> {
-        let expr: LogicalExpression = other.into();
+        let expr: LogicalExpr = other.into();
 
         Ok(Self::Binary {
             left: Py::new(py, self.clone())?,
@@ -143,7 +141,7 @@ impl LogicalExpression {
     }
 
     fn lt_eq(&self, py: Python<'_>, other: Numeric) -> PyResult<Self> {
-        let expr: LogicalExpression = other.into();
+        let expr: LogicalExpr = other.into();
 
         Ok(Self::Binary {
             left: Py::new(py, self.clone())?,
@@ -161,7 +159,7 @@ impl LogicalExpression {
     }
 
     fn gt(&self, py: Python<'_>, other: Numeric) -> PyResult<Self> {
-        let expr: LogicalExpression = other.into();
+        let expr: LogicalExpr = other.into();
 
         Ok(Self::Binary {
             left: Py::new(py, self.clone())?,
@@ -179,7 +177,7 @@ impl LogicalExpression {
     }
 
     fn gt_eq(&self, py: Python<'_>, other: Numeric) -> PyResult<Self> {
-        let expr: LogicalExpression = other.into();
+        let expr: LogicalExpr = other.into();
 
         Ok(Self::Binary {
             left: Py::new(py, self.clone())?,
@@ -199,7 +197,7 @@ impl LogicalExpression {
     // Arithmetic operators
 
     fn add(&self, py: Python<'_>, other: Numeric) -> PyResult<Self> {
-        let expr: LogicalExpression = other.into();
+        let expr: LogicalExpr = other.into();
 
         Ok(Self::Binary {
             left: Py::new(py, self.clone())?,
@@ -217,7 +215,7 @@ impl LogicalExpression {
     }
 
     fn sub(&self, py: Python<'_>, other: Numeric) -> PyResult<Self> {
-        let expr: LogicalExpression = other.into();
+        let expr: LogicalExpr = other.into();
 
         Ok(Self::Binary {
             left: Py::new(py, self.clone())?,
@@ -231,7 +229,7 @@ impl LogicalExpression {
     }
 
     fn __rsub__(&self, py: Python<'_>, other: Numeric) -> PyResult<Self> {
-        let expr: LogicalExpression = other.into();
+        let expr: LogicalExpr = other.into();
 
         Ok(Self::Binary {
             left: Py::new(py, expr)?,
@@ -241,7 +239,7 @@ impl LogicalExpression {
     }
 
     fn mul(&self, py: Python<'_>, other: Numeric) -> PyResult<Self> {
-        let expr: LogicalExpression = other.into();
+        let expr: LogicalExpr = other.into();
 
         Ok(Self::Binary {
             left: Py::new(py, self.clone())?,
@@ -259,7 +257,7 @@ impl LogicalExpression {
     }
 
     fn div(&self, py: Python<'_>, other: Numeric) -> PyResult<Self> {
-        let expr: LogicalExpression = other.into();
+        let expr: LogicalExpr = other.into();
 
         Ok(Self::Binary {
             left: Py::new(py, self.clone())?,
@@ -277,7 +275,7 @@ impl LogicalExpression {
     }
 
     fn __rdiv__(&self, py: Python<'_>, other: Numeric) -> PyResult<Self> {
-        let expr: LogicalExpression = other.into();
+        let expr: LogicalExpr = other.into();
 
         Ok(Self::Binary {
             left: Py::new(py, expr)?,
@@ -287,7 +285,7 @@ impl LogicalExpression {
     }
 
     fn __rtruediv__(&self, py: Python<'_>, other: Numeric) -> PyResult<Self> {
-        let expr: LogicalExpression = other.into();
+        let expr: LogicalExpr = other.into();
 
         Ok(Self::Binary {
             left: Py::new(py, expr)?,
@@ -299,7 +297,7 @@ impl LogicalExpression {
     // Boolean operators
 
     fn and(&self, py: Python<'_>, other: Boolish) -> PyResult<Self> {
-        let expr: LogicalExpression = other.into();
+        let expr: LogicalExpr = other.into();
 
         Ok(Self::Binary {
             left: Py::new(py, self.clone())?,
@@ -317,7 +315,7 @@ impl LogicalExpression {
     }
 
     fn or(&self, py: Python<'_>, other: Boolish) -> PyResult<Self> {
-        let expr: LogicalExpression = other.into();
+        let expr: LogicalExpr = other.into();
 
         Ok(Self::Binary {
             left: Py::new(py, self.clone())?,
@@ -340,28 +338,29 @@ impl LogicalExpression {
         Ok(Self::Binary {
             left: Py::new(py, self.clone())?,
             op: BinaryOperator::StartsWith,
-            right: Py::new(py, Into::<LogicalExpression>::into(other))?,
+            right: Py::new(py, Into::<LogicalExpr>::into(other))?,
         })
     }
 }
 
-impl Into<topk_protos::v1::data::LogicalExpr> for LogicalExpression {
-    fn into(self) -> topk_protos::v1::data::LogicalExpr {
+impl Into<topk_rs::data::logical_expr::LogicalExpr> for LogicalExpr {
+    fn into(self) -> topk_rs::data::logical_expr::LogicalExpr {
         match self {
-            LogicalExpression::Null() => unreachable!(),
-            LogicalExpression::Field { name } => topk_protos::v1::data::LogicalExpr::field(name),
-            LogicalExpression::Literal { value } => {
-                topk_protos::v1::data::LogicalExpr::literal(value.into())
-            }
-            LogicalExpression::Unary { op, expr } => {
-                topk_protos::v1::data::LogicalExpr::unary(op.into(), expr.get().clone().into())
-            }
-            LogicalExpression::Binary { left, op, right } => {
-                topk_protos::v1::data::LogicalExpr::binary(
-                    op.into(),
-                    left.get().clone().into(),
-                    right.get().clone().into(),
-                )
+            LogicalExpr::Null() => topk_rs::data::logical_expr::LogicalExpr::Null(),
+            LogicalExpr::Field { name } => topk_rs::data::logical_expr::LogicalExpr::Field { name },
+            LogicalExpr::Literal { value } => topk_rs::data::logical_expr::LogicalExpr::Literal {
+                value: value.into(),
+            },
+            LogicalExpr::Unary { op, expr } => topk_rs::data::logical_expr::LogicalExpr::Unary {
+                op: op.into(),
+                expr: Box::new(expr.get().clone().into()),
+            },
+            LogicalExpr::Binary { left, op, right } => {
+                topk_rs::data::logical_expr::LogicalExpr::Binary {
+                    left: Box::new(left.get().clone().into()),
+                    op: op.into(),
+                    right: Box::new(right.get().clone().into()),
+                }
             }
         }
     }

--- a/topk-py/src/data/scalar.rs
+++ b/topk-py/src/data/scalar.rs
@@ -8,15 +8,13 @@ pub enum Scalar {
     String(String),
 }
 
-impl Into<topk_protos::v1::data::Value> for Scalar {
-    fn into(self) -> topk_protos::v1::data::Value {
-        topk_protos::v1::data::Value {
-            value: Some(match self {
-                Scalar::Bool(b) => topk_protos::v1::data::value::Value::Bool(b),
-                Scalar::Int(i) => topk_protos::v1::data::value::Value::I64(i),
-                Scalar::Float(f) => topk_protos::v1::data::value::Value::F64(f),
-                Scalar::String(s) => topk_protos::v1::data::value::Value::String(s),
-            }),
+impl Into<topk_rs::data::scalar::Scalar> for Scalar {
+    fn into(self) -> topk_rs::data::scalar::Scalar {
+        match self {
+            Scalar::Bool(b) => topk_rs::data::scalar::Scalar::Bool(b),
+            Scalar::Int(i) => topk_rs::data::scalar::Scalar::I64(i),
+            Scalar::Float(f) => topk_rs::data::scalar::Scalar::F64(f),
+            Scalar::String(s) => topk_rs::data::scalar::Scalar::String(s),
         }
     }
 }

--- a/topk-py/src/data/select_expr.rs
+++ b/topk-py/src/data/select_expr.rs
@@ -1,31 +1,30 @@
-use super::{function_expr::FunctionExpression, logical_expr::LogicalExpression};
+use super::{function_expr::FunctionExpr, logical_expr::LogicalExpr};
 use pyo3::prelude::*;
-use topk_protos::v1::data;
 
 #[pyclass]
 #[derive(Debug, Clone)]
-pub enum SelectExpression {
-    Logical(LogicalExpression),
-    Function(FunctionExpression),
+pub enum SelectExpr {
+    Logical(LogicalExpr),
+    Function(FunctionExpr),
 }
 
 #[derive(Debug, Clone, FromPyObject)]
-pub enum SelectExpressionUnion {
+pub enum SelectExprUnion {
     #[pyo3(transparent)]
-    Logical(LogicalExpression),
+    Logical(LogicalExpr),
 
     #[pyo3(transparent)]
-    Function(FunctionExpression),
+    Function(FunctionExpr),
 }
 
-impl Into<data::stage::select_stage::SelectExpr> for SelectExpression {
-    fn into(self) -> data::stage::select_stage::SelectExpr {
+impl Into<topk_rs::data::select_expr::SelectExpr> for SelectExpr {
+    fn into(self) -> topk_rs::data::select_expr::SelectExpr {
         match self {
-            SelectExpression::Logical(expr) => {
-                data::stage::select_stage::SelectExpr::logical(expr.into())
+            SelectExpr::Logical(expr) => {
+                topk_rs::data::select_expr::SelectExpr::Logical(expr.into())
             }
-            SelectExpression::Function(expr) => {
-                data::stage::select_stage::SelectExpr::function(expr.into())
+            SelectExpr::Function(expr) => {
+                topk_rs::data::select_expr::SelectExpr::Function(expr.into())
             }
         }
     }

--- a/topk-py/src/data/text_expr.rs
+++ b/topk-py/src/data/text_expr.rs
@@ -2,48 +2,48 @@ use pyo3::prelude::*;
 
 #[pyclass]
 #[derive(Debug, Clone)]
-pub enum TextExpression {
+pub enum TextExpr {
     Terms {
         all: bool,
         terms: Vec<Term>,
     },
     And {
-        left: Py<TextExpression>,
-        right: Py<TextExpression>,
+        left: Py<TextExpr>,
+        right: Py<TextExpr>,
     },
     Or {
-        left: Py<TextExpression>,
-        right: Py<TextExpression>,
+        left: Py<TextExpr>,
+        right: Py<TextExpr>,
     },
 }
 
 #[pymethods]
-impl TextExpression {
+impl TextExpr {
     fn __repr__(&self) -> PyResult<String> {
         Ok(format!("{:?}", self))
     }
-    fn __and__(&self, py: Python<'_>, other: TextExpression) -> PyResult<Self> {
+    fn __and__(&self, py: Python<'_>, other: TextExpr) -> PyResult<Self> {
         Ok(Self::And {
             left: Py::new(py, self.clone())?,
             right: Py::new(py, other)?,
         })
     }
 
-    fn __rand__(&self, py: Python<'_>, other: TextExpression) -> PyResult<Self> {
+    fn __rand__(&self, py: Python<'_>, other: TextExpr) -> PyResult<Self> {
         Ok(Self::And {
             left: Py::new(py, other)?,
             right: Py::new(py, self.clone())?,
         })
     }
 
-    fn __or__(&self, py: Python<'_>, other: TextExpression) -> PyResult<Self> {
+    fn __or__(&self, py: Python<'_>, other: TextExpr) -> PyResult<Self> {
         Ok(Self::Or {
             left: Py::new(py, self.clone())?,
             right: Py::new(py, other)?,
         })
     }
 
-    fn __ror__(&self, py: Python<'_>, other: TextExpression) -> PyResult<Self> {
+    fn __ror__(&self, py: Python<'_>, other: TextExpr) -> PyResult<Self> {
         Ok(Self::Or {
             left: Py::new(py, other)?,
             right: Py::new(py, self.clone())?,
@@ -51,21 +51,21 @@ impl TextExpression {
     }
 }
 
-impl Into<topk_protos::v1::data::TextExpr> for TextExpression {
-    fn into(self) -> topk_protos::v1::data::TextExpr {
+impl Into<topk_rs::data::text_expr::TextExpr> for TextExpr {
+    fn into(self) -> topk_rs::data::text_expr::TextExpr {
         match self {
-            TextExpression::Terms { all, terms } => topk_protos::v1::data::TextExpr::terms(
+            TextExpr::Terms { all, terms } => topk_rs::data::text_expr::TextExpr::Terms {
                 all,
-                terms.into_iter().map(|t| t.into()).collect(),
-            ),
-            TextExpression::And { left, right } => topk_protos::v1::data::TextExpr::and(
-                left.get().clone().into(),
-                right.get().clone().into(),
-            ),
-            TextExpression::Or { left, right } => topk_protos::v1::data::TextExpr::or(
-                left.get().clone().into(),
-                right.get().clone().into(),
-            ),
+                terms: terms.into_iter().map(|t| t.into()).collect(),
+            },
+            TextExpr::And { left, right } => topk_rs::data::text_expr::TextExpr::And {
+                left: Box::new(left.get().clone().into()),
+                right: Box::new(right.get().clone().into()),
+            },
+            TextExpr::Or { left, right } => topk_rs::data::text_expr::TextExpr::Or {
+                left: Box::new(left.get().clone().into()),
+                right: Box::new(right.get().clone().into()),
+            },
         }
     }
 }
@@ -78,9 +78,9 @@ pub struct Term {
     pub weight: f32,
 }
 
-impl Into<topk_protos::v1::data::text_expr::Term> for Term {
-    fn into(self) -> topk_protos::v1::data::text_expr::Term {
-        topk_protos::v1::data::text_expr::Term {
+impl Into<topk_rs::data::text_expr::Term> for Term {
+    fn into(self) -> topk_rs::data::text_expr::Term {
+        topk_rs::data::text_expr::Term {
             token: self.token,
             field: self.field,
             weight: self.weight,

--- a/topk-py/src/data/value.rs
+++ b/topk-py/src/data/value.rs
@@ -107,20 +107,12 @@ impl From<ValueUnion> for topk_protos::v1::data::Value {
                 ValueUnion::Null() => {
                     topk_protos::v1::data::value::Value::Null(topk_protos::v1::data::Null {})
                 }
-                ValueUnion::FloatVector(v) => {
-                    topk_protos::v1::data::value::Value::Vector(topk_protos::v1::data::Vector {
-                        vector: Some(topk_protos::v1::data::vector::Vector::Float(
-                            topk_protos::v1::data::vector::Float { values: v },
-                        )),
-                    })
-                }
-                ValueUnion::ByteVector(v) => {
-                    topk_protos::v1::data::value::Value::Vector(topk_protos::v1::data::Vector {
-                        vector: Some(topk_protos::v1::data::vector::Vector::Byte(
-                            topk_protos::v1::data::vector::Byte { values: v },
-                        )),
-                    })
-                }
+                ValueUnion::FloatVector(v) => topk_protos::v1::data::value::Value::Vector(
+                    topk_protos::v1::data::Vector::float(v),
+                ),
+                ValueUnion::ByteVector(v) => topk_protos::v1::data::value::Value::Vector(
+                    topk_protos::v1::data::Vector::byte(v),
+                ),
             }),
         }
     }

--- a/topk-py/src/query.rs
+++ b/topk-py/src/query.rs
@@ -1,6 +1,6 @@
 use crate::data::function_expr::VectorQuery;
 use crate::data::query::Query;
-use crate::data::select_expr::SelectExpressionUnion;
+use crate::data::select_expr::SelectExprUnion;
 use crate::{data, module};
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
@@ -30,7 +30,7 @@ pub fn pymodule(m: &Bound<'_, PyModule>) -> PyResult<()> {
 #[pyo3(signature = (*args, **kwargs))]
 pub fn select(
     args: Vec<String>,
-    kwargs: Option<HashMap<String, SelectExpressionUnion>>,
+    kwargs: Option<HashMap<String, SelectExprUnion>>,
 ) -> PyResult<Query> {
     Ok(Query::new().select(args, kwargs)?)
 }
@@ -41,13 +41,13 @@ pub fn count() -> PyResult<Query> {
 }
 
 #[pyfunction]
-pub fn field(name: String) -> data::logical_expr::LogicalExpression {
-    data::logical_expr::LogicalExpression::Field { name }
+pub fn field(name: String) -> data::logical_expr::LogicalExpr {
+    data::logical_expr::LogicalExpr::Field { name }
 }
 
 #[pyfunction]
-pub fn literal(value: data::scalar::Scalar) -> data::logical_expr::LogicalExpression {
-    data::logical_expr::LogicalExpression::Literal { value }
+pub fn literal(value: data::scalar::Scalar) -> data::logical_expr::LogicalExpr {
+    data::logical_expr::LogicalExpr::Literal { value }
 }
 
 #[pyfunction]
@@ -57,8 +57,8 @@ pub fn r#match(
     field: Option<String>,
     weight: f32,
     all: bool,
-) -> data::text_expr::TextExpression {
-    data::text_expr::TextExpression::Terms {
+) -> data::text_expr::TextExpr {
+    data::text_expr::TextExpr::Terms {
         all,
         terms: vec![data::text_expr::Term {
             token,
@@ -79,8 +79,8 @@ pub fn fn_pymodule(m: &Bound<'_, PyModule>) -> PyResult<()> {
 }
 
 #[pyfunction]
-pub fn bm25_score() -> data::function_expr::FunctionExpression {
-    data::function_expr::FunctionExpression::KeywordScore {}
+pub fn bm25_score() -> data::function_expr::FunctionExpr {
+    data::function_expr::FunctionExpr::KeywordScore {}
 }
 
 #[derive(Debug, Clone)]
@@ -118,11 +118,8 @@ impl<'py> FromPyObject<'py> for VectorQueryArg {
 }
 
 #[pyfunction]
-pub fn vector_distance(
-    field: String,
-    query: VectorQueryArg,
-) -> data::function_expr::FunctionExpression {
-    data::function_expr::FunctionExpression::VectorScore {
+pub fn vector_distance(field: String, query: VectorQueryArg) -> data::function_expr::FunctionExpr {
+    data::function_expr::FunctionExpr::VectorScore {
         field,
         query: match query {
             VectorQueryArg::F32(values) => VectorQuery::F32(values),
@@ -132,9 +129,6 @@ pub fn vector_distance(
 }
 
 #[pyfunction]
-pub fn semantic_similarity(
-    field: String,
-    query: String,
-) -> data::function_expr::FunctionExpression {
-    data::function_expr::FunctionExpression::SemanticSimilarity { field, query }
+pub fn semantic_similarity(field: String, query: String) -> data::function_expr::FunctionExpr {
+    data::function_expr::FunctionExpr::SemanticSimilarity { field, query }
 }

--- a/topk-rs/src/data/expr_binary.rs
+++ b/topk-rs/src/data/expr_binary.rs
@@ -1,0 +1,45 @@
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum BinaryOperator {
+    // Logical ops
+    And,
+    Or,
+    Xor,
+    // Comparison ops
+    Eq,
+    NotEq,
+    Lt,
+    LtEq,
+    Gt,
+    GtEq,
+    StartsWith,
+    // Arithmetic ops
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Rem,
+}
+
+impl Into<topk_protos::v1::data::logical_expr::binary_op::Op> for BinaryOperator {
+    fn into(self) -> topk_protos::v1::data::logical_expr::binary_op::Op {
+        match self {
+            BinaryOperator::Eq => topk_protos::v1::data::logical_expr::binary_op::Op::Eq,
+            BinaryOperator::NotEq => topk_protos::v1::data::logical_expr::binary_op::Op::Neq,
+            BinaryOperator::Lt => topk_protos::v1::data::logical_expr::binary_op::Op::Lt,
+            BinaryOperator::LtEq => topk_protos::v1::data::logical_expr::binary_op::Op::Lte,
+            BinaryOperator::Gt => topk_protos::v1::data::logical_expr::binary_op::Op::Gt,
+            BinaryOperator::GtEq => topk_protos::v1::data::logical_expr::binary_op::Op::Gte,
+            BinaryOperator::StartsWith => {
+                topk_protos::v1::data::logical_expr::binary_op::Op::StartsWith
+            }
+            BinaryOperator::Add => topk_protos::v1::data::logical_expr::binary_op::Op::Add,
+            BinaryOperator::Sub => topk_protos::v1::data::logical_expr::binary_op::Op::Sub,
+            BinaryOperator::Mul => topk_protos::v1::data::logical_expr::binary_op::Op::Mul,
+            BinaryOperator::Div => topk_protos::v1::data::logical_expr::binary_op::Op::Div,
+            BinaryOperator::And => topk_protos::v1::data::logical_expr::binary_op::Op::And,
+            BinaryOperator::Or => topk_protos::v1::data::logical_expr::binary_op::Op::Or,
+            BinaryOperator::Xor => unreachable!("Xor is not supported"),
+            BinaryOperator::Rem => unreachable!("Rem is not supported"),
+        }
+    }
+}

--- a/topk-rs/src/data/expr_unary.rs
+++ b/topk-rs/src/data/expr_unary.rs
@@ -1,0 +1,18 @@
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum UnaryOperator {
+    Not,
+    IsNull,
+    IsNotNull,
+}
+
+impl Into<topk_protos::v1::data::logical_expr::unary_op::Op> for UnaryOperator {
+    fn into(self) -> topk_protos::v1::data::logical_expr::unary_op::Op {
+        match self {
+            UnaryOperator::Not => topk_protos::v1::data::logical_expr::unary_op::Op::Not,
+            UnaryOperator::IsNull => topk_protos::v1::data::logical_expr::unary_op::Op::IsNull,
+            UnaryOperator::IsNotNull => {
+                topk_protos::v1::data::logical_expr::unary_op::Op::IsNotNull
+            }
+        }
+    }
+}

--- a/topk-rs/src/data/filter_expr.rs
+++ b/topk-rs/src/data/filter_expr.rs
@@ -1,0 +1,29 @@
+use super::{logical_expr::LogicalExpr, text_expr::TextExpr};
+use topk_protos::v1::data::stage::filter_stage::FilterExpr as FilterExprPb;
+
+#[derive(Debug, Clone)]
+pub enum FilterExpr {
+    Logical(LogicalExpr),
+    Text(TextExpr),
+}
+
+impl Into<FilterExprPb> for FilterExpr {
+    fn into(self) -> FilterExprPb {
+        match self {
+            FilterExpr::Logical(expr) => FilterExprPb::logical(expr.into()),
+            FilterExpr::Text(expr) => FilterExprPb::text(expr.into()),
+        }
+    }
+}
+
+impl From<LogicalExpr> for FilterExpr {
+    fn from(expr: LogicalExpr) -> Self {
+        FilterExpr::Logical(expr)
+    }
+}
+
+impl From<TextExpr> for FilterExpr {
+    fn from(expr: TextExpr) -> Self {
+        FilterExpr::Text(expr)
+    }
+}

--- a/topk-rs/src/data/function_expr.rs
+++ b/topk-rs/src/data/function_expr.rs
@@ -1,0 +1,63 @@
+#[derive(Debug, Clone)]
+pub enum Vector {
+    F32(Vec<f32>),
+    U8(Vec<u8>),
+}
+
+impl Vector {
+    pub fn float(values: Vec<f32>) -> Self {
+        Self::F32(values)
+    }
+
+    pub fn byte(values: Vec<u8>) -> Self {
+        Self::U8(values)
+    }
+}
+
+impl Into<topk_protos::v1::data::Vector> for Vector {
+    fn into(self) -> topk_protos::v1::data::Vector {
+        match self {
+            Vector::F32(values) => topk_protos::v1::data::Vector::float(values),
+            Vector::U8(values) => topk_protos::v1::data::Vector::byte(values),
+        }
+    }
+}
+
+impl From<topk_protos::v1::data::Vector> for Vector {
+    fn from(vector: topk_protos::v1::data::Vector) -> Self {
+        match vector.vector {
+            Some(topk_protos::v1::data::vector::Vector::Float(values)) => {
+                Vector::F32(values.values)
+            }
+            Some(topk_protos::v1::data::vector::Vector::Byte(values)) => Vector::U8(values.values),
+            t => panic!("Invalid vector type: {:?}", t),
+        }
+    }
+}
+
+impl From<Vec<f32>> for Vector {
+    fn from(values: Vec<f32>) -> Self {
+        Vector::F32(values)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum FunctionExpr {
+    KeywordScore {},
+    VectorScore { field: String, query: Vector },
+    SemanticSimilarity { field: String, query: String },
+}
+
+impl Into<topk_protos::v1::data::FunctionExpr> for FunctionExpr {
+    fn into(self) -> topk_protos::v1::data::FunctionExpr {
+        match self {
+            FunctionExpr::KeywordScore {} => topk_protos::v1::data::FunctionExpr::bm25_score(),
+            FunctionExpr::VectorScore { field, query } => {
+                topk_protos::v1::data::FunctionExpr::vector_distance(field, query.into())
+            }
+            FunctionExpr::SemanticSimilarity { field, query } => {
+                topk_protos::v1::data::FunctionExpr::semantic_similarity(field, query)
+            }
+        }
+    }
+}

--- a/topk-rs/src/data/logical_expr.rs
+++ b/topk-rs/src/data/logical_expr.rs
@@ -1,0 +1,199 @@
+use super::{expr_binary::BinaryOperator, expr_unary::UnaryOperator, scalar::Scalar};
+
+#[derive(Clone, Debug)]
+pub enum LogicalExpr {
+    Null(),
+    Field {
+        name: String,
+    },
+    Literal {
+        value: Scalar,
+    },
+    Unary {
+        op: UnaryOperator,
+        expr: Box<LogicalExpr>,
+    },
+    Binary {
+        left: Box<LogicalExpr>,
+        op: BinaryOperator,
+        right: Box<LogicalExpr>,
+    },
+}
+
+impl LogicalExpr {
+    // Comparison operators
+    pub fn eq(&self, other: impl Into<LogicalExpr>) -> Self {
+        Self::Binary {
+            left: Box::new(self.clone()),
+            op: BinaryOperator::Eq,
+            right: Box::new(other.into()),
+        }
+    }
+
+    pub fn ne(&self, other: impl Into<LogicalExpr>) -> Self {
+        Self::Binary {
+            left: Box::new(self.clone()),
+            op: BinaryOperator::NotEq,
+            right: Box::new(other.into()),
+        }
+    }
+
+    pub fn lt(&self, other: impl Into<LogicalExpr>) -> Self {
+        Self::Binary {
+            left: Box::new(self.clone()),
+            op: BinaryOperator::Lt,
+            right: Box::new(other.into()),
+        }
+    }
+
+    pub fn lte(&self, other: impl Into<LogicalExpr>) -> Self {
+        Self::Binary {
+            left: Box::new(self.clone()),
+            op: BinaryOperator::LtEq,
+            right: Box::new(other.into()),
+        }
+    }
+
+    pub fn gt(&self, other: impl Into<LogicalExpr>) -> Self {
+        Self::Binary {
+            left: Box::new(self.clone()),
+            op: BinaryOperator::Gt,
+            right: Box::new(other.into()),
+        }
+    }
+
+    pub fn gte(&self, other: impl Into<LogicalExpr>) -> Self {
+        Self::Binary {
+            left: Box::new(self.clone()),
+            op: BinaryOperator::GtEq,
+            right: Box::new(other.into()),
+        }
+    }
+
+    // Arithmetic operators
+    pub fn add(&self, other: impl Into<LogicalExpr>) -> Self {
+        Self::Binary {
+            left: Box::new(self.clone()),
+            op: BinaryOperator::Add,
+            right: Box::new(other.into()),
+        }
+    }
+
+    pub fn sub(&self, other: impl Into<LogicalExpr>) -> Self {
+        Self::Binary {
+            left: Box::new(self.clone()),
+            op: BinaryOperator::Sub,
+            right: Box::new(other.into()),
+        }
+    }
+
+    pub fn mul(&self, other: impl Into<LogicalExpr>) -> Self {
+        Self::Binary {
+            left: Box::new(self.clone()),
+            op: BinaryOperator::Mul,
+            right: Box::new(other.into()),
+        }
+    }
+
+    pub fn div(&self, other: impl Into<LogicalExpr>) -> Self {
+        Self::Binary {
+            left: Box::new(self.clone()),
+            op: BinaryOperator::Div,
+            right: Box::new(other.into()),
+        }
+    }
+
+    // Boolean operators
+    pub fn and(&self, other: impl Into<LogicalExpr>) -> Self {
+        Self::Binary {
+            left: Box::new(self.clone()),
+            op: BinaryOperator::And,
+            right: Box::new(other.into()),
+        }
+    }
+
+    pub fn or(&self, other: impl Into<LogicalExpr>) -> Self {
+        Self::Binary {
+            left: Box::new(self.clone()),
+            op: BinaryOperator::Or,
+            right: Box::new(other.into()),
+        }
+    }
+
+    // String operators
+    pub fn starts_with(&self, other: impl Into<LogicalExpr>) -> Self {
+        Self::Binary {
+            left: Box::new(self.clone()),
+            op: BinaryOperator::StartsWith,
+            right: Box::new(other.into()),
+        }
+    }
+}
+
+impl std::ops::Add for LogicalExpr {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        LogicalExpr::add(&self, other)
+    }
+}
+
+impl std::ops::Sub for LogicalExpr {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self {
+        LogicalExpr::sub(&self, other)
+    }
+}
+
+impl std::ops::Mul for LogicalExpr {
+    type Output = Self;
+
+    fn mul(self, other: Self) -> Self {
+        LogicalExpr::mul(&self, other)
+    }
+}
+
+impl std::ops::Div for LogicalExpr {
+    type Output = Self;
+
+    fn div(self, other: Self) -> Self {
+        LogicalExpr::div(&self, other)
+    }
+}
+
+impl From<u32> for LogicalExpr {
+    fn from(value: u32) -> Self {
+        LogicalExpr::Literal {
+            value: Scalar::U32(value),
+        }
+    }
+}
+
+impl From<&'static str> for LogicalExpr {
+    fn from(value: &'static str) -> Self {
+        LogicalExpr::Literal {
+            value: Scalar::String(value.to_string()),
+        }
+    }
+}
+
+impl Into<topk_protos::v1::data::LogicalExpr> for LogicalExpr {
+    fn into(self) -> topk_protos::v1::data::LogicalExpr {
+        match self {
+            LogicalExpr::Null() => unreachable!(),
+            LogicalExpr::Field { name } => topk_protos::v1::data::LogicalExpr::field(name),
+            LogicalExpr::Literal { value } => {
+                topk_protos::v1::data::LogicalExpr::literal(value.into())
+            }
+            LogicalExpr::Unary { op, expr } => {
+                topk_protos::v1::data::LogicalExpr::unary(op.into(), (*expr).into())
+            }
+            LogicalExpr::Binary { left, op, right } => topk_protos::v1::data::LogicalExpr::binary(
+                op.into(),
+                (*left).into(),
+                (*right).into(),
+            ),
+        }
+    }
+}

--- a/topk-rs/src/data/mod.rs
+++ b/topk-rs/src/data/mod.rs
@@ -1,0 +1,9 @@
+pub mod expr_binary;
+pub mod expr_unary;
+pub mod filter_expr;
+pub mod function_expr;
+pub mod logical_expr;
+pub mod scalar;
+pub mod select_expr;
+pub mod stage;
+pub mod text_expr;

--- a/topk-rs/src/data/scalar.rs
+++ b/topk-rs/src/data/scalar.rs
@@ -1,0 +1,70 @@
+#[derive(Debug, Clone, PartialEq)]
+pub enum Scalar {
+    Bool(bool),
+    U32(u32),
+    U64(u64),
+    I32(i32),
+    I64(i64),
+    F32(f32),
+    F64(f64),
+    String(String),
+}
+
+impl From<bool> for Scalar {
+    fn from(value: bool) -> Self {
+        Scalar::Bool(value)
+    }
+}
+
+impl From<u32> for Scalar {
+    fn from(value: u32) -> Self {
+        Scalar::U32(value)
+    }
+}
+
+impl From<u64> for Scalar {
+    fn from(value: u64) -> Self {
+        Scalar::U64(value)
+    }
+}
+
+impl From<i32> for Scalar {
+    fn from(value: i32) -> Self {
+        Scalar::I32(value)
+    }
+}
+
+impl From<i64> for Scalar {
+    fn from(value: i64) -> Self {
+        Scalar::I64(value)
+    }
+}
+
+impl From<f32> for Scalar {
+    fn from(value: f32) -> Self {
+        Scalar::F32(value)
+    }
+}
+
+impl From<f64> for Scalar {
+    fn from(value: f64) -> Self {
+        Scalar::F64(value)
+    }
+}
+
+impl Into<topk_protos::v1::data::Value> for Scalar {
+    fn into(self) -> topk_protos::v1::data::Value {
+        topk_protos::v1::data::Value {
+            value: Some(match self {
+                Scalar::Bool(b) => topk_protos::v1::data::value::Value::Bool(b),
+                Scalar::I32(i) => topk_protos::v1::data::value::Value::I32(i),
+                Scalar::I64(i) => topk_protos::v1::data::value::Value::I64(i),
+                Scalar::F32(f) => topk_protos::v1::data::value::Value::F32(f),
+                Scalar::F64(f) => topk_protos::v1::data::value::Value::F64(f),
+                Scalar::U32(u) => topk_protos::v1::data::value::Value::U32(u),
+                Scalar::U64(u) => topk_protos::v1::data::value::Value::U64(u),
+                Scalar::String(s) => topk_protos::v1::data::value::Value::String(s),
+            }),
+        }
+    }
+}

--- a/topk-rs/src/data/select_expr.rs
+++ b/topk-rs/src/data/select_expr.rs
@@ -1,0 +1,33 @@
+use super::{function_expr::FunctionExpr, logical_expr::LogicalExpr};
+use topk_protos::v1::data;
+
+#[derive(Debug, Clone)]
+pub enum SelectExpr {
+    Logical(LogicalExpr),
+    Function(FunctionExpr),
+}
+
+impl From<LogicalExpr> for SelectExpr {
+    fn from(expr: LogicalExpr) -> Self {
+        SelectExpr::Logical(expr)
+    }
+}
+
+impl From<FunctionExpr> for SelectExpr {
+    fn from(expr: FunctionExpr) -> Self {
+        SelectExpr::Function(expr)
+    }
+}
+
+impl Into<data::stage::select_stage::SelectExpr> for SelectExpr {
+    fn into(self) -> data::stage::select_stage::SelectExpr {
+        match self {
+            SelectExpr::Logical(expr) => {
+                data::stage::select_stage::SelectExpr::logical(expr.into())
+            }
+            SelectExpr::Function(expr) => {
+                data::stage::select_stage::SelectExpr::function(expr.into())
+            }
+        }
+    }
+}

--- a/topk-rs/src/data/stage.rs
+++ b/topk-rs/src/data/stage.rs
@@ -1,0 +1,43 @@
+use super::{filter_expr::FilterExpr, logical_expr::LogicalExpr, select_expr::SelectExpr};
+use std::collections::HashMap;
+
+#[derive(Clone)]
+pub enum Stage {
+    Select {
+        exprs: HashMap<String, SelectExpr>,
+    },
+    Filter {
+        expr: FilterExpr,
+    },
+    TopK {
+        expr: LogicalExpr,
+        k: u64,
+        asc: bool,
+    },
+    Count {},
+    Rerank {
+        model: Option<String>,
+        query: Option<String>,
+        fields: Vec<String>,
+        topk_multiple: Option<u32>,
+    },
+}
+
+impl From<Stage> for topk_protos::v1::data::Stage {
+    fn from(stage: Stage) -> Self {
+        match stage {
+            Stage::Select { exprs } => topk_protos::v1::data::Stage::select(exprs),
+            Stage::Filter { expr } => topk_protos::v1::data::Stage::filter(expr),
+            Stage::TopK { expr, k, asc } => {
+                topk_protos::v1::data::Stage::top_k(expr.into(), k, asc)
+            }
+            Stage::Count {} => topk_protos::v1::data::Stage::count(),
+            Stage::Rerank {
+                model,
+                query,
+                fields,
+                topk_multiple,
+            } => topk_protos::v1::data::Stage::rerank(model, query, fields, topk_multiple),
+        }
+    }
+}

--- a/topk-rs/src/data/text_expr.rs
+++ b/topk-rs/src/data/text_expr.rs
@@ -1,0 +1,65 @@
+#[derive(Debug, Clone)]
+pub enum TextExpr {
+    Terms {
+        all: bool,
+        terms: Vec<Term>,
+    },
+    And {
+        left: Box<TextExpr>,
+        right: Box<TextExpr>,
+    },
+    Or {
+        left: Box<TextExpr>,
+        right: Box<TextExpr>,
+    },
+}
+
+impl TextExpr {
+    pub fn and(&self, other: TextExpr) -> Self {
+        Self::And {
+            left: Box::new(self.clone()),
+            right: Box::new(other),
+        }
+    }
+
+    pub fn or(&self, other: TextExpr) -> Self {
+        Self::Or {
+            left: Box::new(self.clone()),
+            right: Box::new(other),
+        }
+    }
+}
+
+impl Into<topk_protos::v1::data::TextExpr> for TextExpr {
+    fn into(self) -> topk_protos::v1::data::TextExpr {
+        match self {
+            TextExpr::Terms { all, terms } => topk_protos::v1::data::TextExpr::terms(
+                all,
+                terms.into_iter().map(|t| t.into()).collect(),
+            ),
+            TextExpr::And { left, right } => {
+                topk_protos::v1::data::TextExpr::and((*left).into(), (*right).into())
+            }
+            TextExpr::Or { left, right } => {
+                topk_protos::v1::data::TextExpr::or((*left).into(), (*right).into())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Term {
+    pub token: String,
+    pub field: Option<String>,
+    pub weight: f32,
+}
+
+impl Into<topk_protos::v1::data::text_expr::Term> for Term {
+    fn into(self) -> topk_protos::v1::data::text_expr::Term {
+        topk_protos::v1::data::text_expr::Term {
+            token: self.token,
+            field: self.field,
+            weight: self.weight,
+        }
+    }
+}

--- a/topk-rs/src/lib.rs
+++ b/topk-rs/src/lib.rs
@@ -2,6 +2,9 @@ mod client;
 mod errors;
 mod internal_error_code;
 
+pub mod data;
+pub mod query;
+
 pub use client::ClientConfig;
 pub use client::{Client, CollectionClient};
 pub use errors::SchemaValidationError;
@@ -49,4 +52,7 @@ pub enum Error {
 
     #[error("channel not initialized")]
     TransportChannelNotInitialized,
+
+    #[error("malformed response: {0}")]
+    MalformedResponse(String),
 }

--- a/topk-rs/src/query.rs
+++ b/topk-rs/src/query.rs
@@ -1,0 +1,154 @@
+pub use crate::data::stage::Stage;
+use crate::data::{
+    filter_expr::FilterExpr,
+    logical_expr::LogicalExpr,
+    scalar::Scalar,
+    select_expr::SelectExpr,
+    text_expr::{Term, TextExpr},
+};
+use std::collections::HashMap;
+
+#[derive(Clone)]
+pub struct Query {
+    stages: Vec<Stage>,
+}
+
+impl Query {
+    pub fn new(stages: Vec<Stage>) -> Self {
+        Self { stages }
+    }
+
+    pub fn select<S, E>(&self, exprs: impl IntoIterator<Item = (S, E)>) -> Self
+    where
+        S: Into<String>,
+        E: Into<SelectExpr>,
+    {
+        let mut query = self.clone();
+        query.stages.push(Stage::Select {
+            exprs: exprs
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        });
+        query
+    }
+
+    pub fn filter(&self, expr: impl Into<FilterExpr>) -> Self {
+        let mut query = self.clone();
+        query.stages.push(Stage::Filter {
+            expr: expr.into().into(),
+        });
+        query
+    }
+
+    pub fn top_k(&self, expr: impl Into<LogicalExpr>, limit: u64, asc: bool) -> Self {
+        let mut query = self.clone();
+        query.stages.push(Stage::TopK {
+            expr: expr.into().into(),
+            k: limit,
+            asc,
+        });
+        query
+    }
+
+    pub fn count(&self) -> Self {
+        let mut query = self.clone();
+        query.stages.push(Stage::Count {});
+        query
+    }
+
+    pub fn rerank(
+        &self,
+        model: Option<String>,
+        query: Option<String>,
+        fields: Vec<String>,
+        topk_multiple: Option<u32>,
+    ) -> Self {
+        let mut new_query = self.clone();
+        new_query.stages.push(Stage::Rerank {
+            model,
+            query,
+            fields,
+            topk_multiple,
+        });
+        new_query
+    }
+}
+impl From<Query> for topk_protos::v1::data::Query {
+    fn from(query: Query) -> Self {
+        Self {
+            stages: query.stages.into_iter().map(|s| s.into()).collect(),
+        }
+    }
+}
+
+pub fn select<S, E>(exprs: impl IntoIterator<Item = (S, E)>) -> Query
+where
+    S: Into<String>,
+    E: Into<SelectExpr>,
+{
+    let exprs: HashMap<String, SelectExpr> = exprs
+        .into_iter()
+        .map(|(k, v)| (k.into(), v.into()))
+        .collect();
+
+    Query::new(vec![]).select(exprs)
+}
+
+// TODO: `filter` and `top_k` are not exported from python
+pub fn filter(expr: impl Into<FilterExpr>) -> Query {
+    Query::new(vec![]).filter(expr.into())
+}
+
+pub fn top_k(expr: impl Into<LogicalExpr>, limit: u64, asc: bool) -> Query {
+    Query::new(vec![]).top_k(expr, limit, asc)
+}
+
+pub fn field<S>(name: S) -> LogicalExpr
+where
+    S: Into<String>,
+{
+    LogicalExpr::Field { name: name.into() }
+}
+
+pub fn literal<V>(value: V) -> LogicalExpr
+where
+    V: Into<Scalar>,
+{
+    LogicalExpr::Literal {
+        value: value.into(),
+    }
+}
+
+pub fn r#match(value: &str, field: Option<&str>, weight: Option<f32>) -> TextExpr {
+    TextExpr::Terms {
+        all: false,
+        terms: vec![Term {
+            token: value.to_string(),
+            field: field.map(|f| f.to_string()),
+            weight: weight.unwrap_or(1.0),
+        }],
+    }
+}
+
+pub mod fns {
+    use crate::data::function_expr::{FunctionExpr, Vector};
+
+    pub fn bm25_score() -> FunctionExpr {
+        FunctionExpr::KeywordScore {}
+    }
+
+    pub fn vector_distance(field: &str, query: impl Into<Vector>) -> FunctionExpr {
+        FunctionExpr::VectorScore {
+            field: field.to_string(),
+            query: query.into(),
+        }
+    }
+
+    pub fn semantic_similarity(field: &str, query: &str) -> FunctionExpr {
+        FunctionExpr::SemanticSimilarity {
+            field: field.to_string(),
+            query: query.to_string(),
+        }
+    }
+}

--- a/topk-rs/tests/test_delete.rs
+++ b/topk-rs/tests/test_delete.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use test_context::test_context;
 use topk_protos::doc;
-use topk_protos::v1::data::{LogicalExpr, Query, Stage};
+use topk_rs::query::{field, top_k};
 use topk_rs::Error;
 
 mod utils;
@@ -44,7 +44,7 @@ async fn test_delete_document(ctx: &mut ProjectTestContext) {
     // wait for write to be flushed
     ctx.client
         .collection(&collection.name)
-        .query(Query::new(vec![Stage::count()]), None, None)
+        .count(None, None)
         .await
         .expect("could not query documents");
 
@@ -59,11 +59,7 @@ async fn test_delete_document(ctx: &mut ProjectTestContext) {
     let docs = ctx
         .client
         .collection(&collection.name)
-        .query(
-            Query::new(vec![Stage::topk(LogicalExpr::field("rank"), 100, true)]),
-            Some(lsn),
-            None,
-        )
+        .query(top_k(field("rank"), 100, true), Some(lsn), None)
         .await
         .expect("could not query documents");
 

--- a/topk-rs/tests/test_query_count.rs
+++ b/topk-rs/tests/test_query_count.rs
@@ -1,8 +1,6 @@
 use test_context::test_context;
-use topk_protos::{
-    doc,
-    v1::data::{stage::filter_stage::FilterExpr, LogicalExpr, Query, Stage},
-};
+use topk_protos::doc;
+use topk_rs::query::{field, filter};
 use topk_rs::Error;
 
 mod utils;
@@ -15,7 +13,7 @@ async fn test_query_non_existent_collection(ctx: &mut ProjectTestContext) {
     let err = ctx
         .client
         .collection("missing")
-        .query(Query::new(vec![Stage::count()]), None, None)
+        .count(None, None)
         .await
         .expect_err("should not be able to query non-existent collection");
 
@@ -30,11 +28,11 @@ async fn test_query_count(ctx: &mut ProjectTestContext) {
     let result = ctx
         .client
         .collection(&collection.name)
-        .query(Query::new(vec![Stage::count()]), None, None)
+        .count(None, None)
         .await
         .expect("could not query");
 
-    assert_eq!(result, vec![doc!("_count" => 10_u64)]);
+    assert_eq!(result, 10_u64);
 }
 
 #[test_context(ProjectTestContext)]
@@ -42,18 +40,14 @@ async fn test_query_count(ctx: &mut ProjectTestContext) {
 async fn test_query_count_with_filter(ctx: &mut ProjectTestContext) {
     let collection = dataset::books::setup(ctx).await;
 
-    let query = Query::new(vec![
-        Stage::filter(FilterExpr::logical(LogicalExpr::lte(
-            LogicalExpr::field("published_year"),
-            LogicalExpr::literal((1950 as u32).into()),
-        ))),
-        Stage::count(),
-    ]);
-
     let result = ctx
         .client
         .collection(&collection.name)
-        .query(query, None, None)
+        .query(
+            filter(field("published_year").lte(1950 as u32)).count(),
+            None,
+            None,
+        )
         .await
         .expect("could not query");
 
@@ -68,11 +62,11 @@ async fn test_query_count_with_delete(ctx: &mut ProjectTestContext) {
     let result = ctx
         .client
         .collection(&collection.name)
-        .query(Query::new(vec![Stage::count()]), None, None)
+        .count(None, None)
         .await
         .expect("could not query");
 
-    assert_eq!(result, vec![doc!("_count" => 10_u64)]);
+    assert_eq!(result, 10_u64);
 
     let lsn = ctx
         .client
@@ -84,9 +78,9 @@ async fn test_query_count_with_delete(ctx: &mut ProjectTestContext) {
     let result = ctx
         .client
         .collection(&collection.name)
-        .query(Query::new(vec![Stage::count()]), Some(lsn), None)
+        .count(Some(lsn), None)
         .await
         .expect("could not query");
 
-    assert_eq!(result, vec![doc!("_count" => 9_u64)]);
+    assert_eq!(result, 9_u64);
 }

--- a/topk-rs/tests/test_query_filter.rs
+++ b/topk-rs/tests/test_query_filter.rs
@@ -1,5 +1,6 @@
 use test_context::test_context;
-use topk_protos::v1::data::{stage::filter_stage::FilterExpr, LogicalExpr, Query, Stage};
+use topk_rs::query::field;
+use topk_rs::query::filter;
 
 mod utils;
 use utils::dataset;
@@ -14,13 +15,7 @@ async fn test_query_starts_with(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            Query::new(vec![
-                Stage::filter(FilterExpr::logical(LogicalExpr::starts_with(
-                    LogicalExpr::field("_id"),
-                    LogicalExpr::literal("cat".into()),
-                ))),
-                Stage::topk(LogicalExpr::field("published_year"), 100, false),
-            ]),
+            filter(field("_id").starts_with("cat")).top_k(field("published_year"), 100, false),
             None,
             None,
         )
@@ -39,13 +34,7 @@ async fn test_query_starts_with_empty(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            Query::new(vec![
-                Stage::filter(FilterExpr::logical(LogicalExpr::starts_with(
-                    LogicalExpr::field("_id"),
-                    LogicalExpr::literal("".into()),
-                ))),
-                Stage::topk(LogicalExpr::field("published_year"), 100, false),
-            ]),
+            filter(field("_id").starts_with("")).top_k(field("published_year"), 100, false),
             None,
             None,
         )
@@ -78,13 +67,11 @@ async fn test_query_starts_with_non_existent_prefix(ctx: &mut ProjectTestContext
         .client
         .collection(&collection.name)
         .query(
-            Query::new(vec![
-                Stage::filter(FilterExpr::logical(LogicalExpr::starts_with(
-                    LogicalExpr::field("_id"),
-                    LogicalExpr::literal("foobarbaz".into()),
-                ))),
-                Stage::topk(LogicalExpr::field("published_year"), 100, false),
-            ]),
+            filter(field("_id").starts_with("foobarbaz")).top_k(
+                field("published_year"),
+                100,
+                false,
+            ),
             None,
             None,
         )

--- a/topk-rs/tests/test_query_logical.rs
+++ b/topk-rs/tests/test_query_logical.rs
@@ -1,5 +1,6 @@
 use test_context::test_context;
-use topk_protos::v1::data::{stage::filter_stage::FilterExpr, LogicalExpr, Query, Stage};
+use topk_rs::query::field;
+use topk_rs::query::filter;
 
 mod utils;
 use utils::dataset;
@@ -14,13 +15,11 @@ async fn test_query_lte(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            Query::new(vec![
-                Stage::filter(FilterExpr::logical(LogicalExpr::lte(
-                    LogicalExpr::field("published_year"),
-                    LogicalExpr::literal((1950 as u32).into()),
-                ))),
-                Stage::topk(LogicalExpr::field("published_year"), 100, true),
-            ]),
+            filter(field("published_year").lte(1950 as u32)).top_k(
+                field("published_year"),
+                100,
+                true,
+            ),
             None,
             None,
         )
@@ -39,19 +38,12 @@ async fn test_query_and(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            Query::new(vec![
-                Stage::filter(FilterExpr::logical(LogicalExpr::and(
-                    LogicalExpr::lte(
-                        LogicalExpr::field("published_year"),
-                        LogicalExpr::literal((1950 as u32).into()),
-                    ),
-                    LogicalExpr::gte(
-                        LogicalExpr::field("published_year"),
-                        LogicalExpr::literal((1948 as u32).into()),
-                    ),
-                ))),
-                Stage::topk(LogicalExpr::field("published_year"), 100, true),
-            ]),
+            filter(
+                field("published_year")
+                    .lte(1950 as u32)
+                    .and(field("published_year").gte(1948 as u32)),
+            )
+            .top_k(field("published_year"), 100, true),
             None,
             None,
         )

--- a/topk-rs/tests/test_query_select_union.rs
+++ b/topk-rs/tests/test_query_select_union.rs
@@ -1,11 +1,9 @@
 use std::collections::HashMap;
 use test_context::test_context;
-use topk_protos::{
-    doc,
-    v1::data::{stage::select_stage::SelectExpr, LogicalExpr, Query, Stage, Value},
-};
+use topk_protos::{doc, v1::data::Value};
 
 mod utils;
+use topk_rs::query::{field, select};
 use utils::ProjectTestContext;
 
 #[test_context(ProjectTestContext)]
@@ -43,7 +41,7 @@ async fn test_query_select_union(ctx: &mut ProjectTestContext) {
     let _ = ctx
         .client
         .collection(&collection.name)
-        .query(Query::new(vec![Stage::count()]), Some(lsn), None)
+        .count(Some(lsn), None)
         .await
         .expect("could not query");
 
@@ -51,13 +49,7 @@ async fn test_query_select_union(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            Query::new(vec![
-                Stage::select(HashMap::from([(
-                    "mixed".to_string(),
-                    SelectExpr::logical(LogicalExpr::field("mixed")),
-                )])),
-                Stage::topk(LogicalExpr::field("rank"), 100, true),
-            ]),
+            select([("mixed", field("mixed"))]).top_k(field("rank"), 100, true),
             None,
             None,
         )

--- a/topk-rs/tests/test_query_text.rs
+++ b/topk-rs/tests/test_query_text.rs
@@ -1,13 +1,9 @@
-use std::collections::HashMap;
 use test_context::test_context;
-use topk_protos::v1::data::{
-    stage::{filter_stage::FilterExpr, select_stage::SelectExpr},
-    text_expr::Term,
-    FunctionExpr, LogicalExpr, Query, Stage, TextExpr,
-};
-
 mod utils;
-use topk_rs::Error;
+use topk_rs::{
+    query::{field, filter, fns, r#match, select},
+    Error,
+};
 use utils::dataset;
 use utils::ProjectTestContext;
 
@@ -20,17 +16,11 @@ async fn test_query_text_filter_single_term_disjunctive(ctx: &mut ProjectTestCon
         .client
         .collection(&collection.name)
         .query(
-            Query::new(vec![
-                Stage::filter(FilterExpr::text(TextExpr::terms(
-                    false,
-                    vec![Term {
-                        token: "love".to_string(),
-                        field: Some("summary".to_string()),
-                        weight: 1.0,
-                    }],
-                ))),
-                Stage::topk(LogicalExpr::field("published_year"), 100, true),
-            ]),
+            filter(r#match("love", Some("summary"), None)).top_k(
+                field("published_year"),
+                100,
+                true,
+            ),
             None,
             None,
         )
@@ -49,17 +39,11 @@ async fn test_query_text_filter_single_term_conjunctive(ctx: &mut ProjectTestCon
         .client
         .collection(&collection.name)
         .query(
-            Query::new(vec![
-                Stage::filter(FilterExpr::text(TextExpr::terms(
-                    true,
-                    vec![Term {
-                        token: "love".to_string(),
-                        field: Some("summary".to_string()),
-                        weight: 1.0,
-                    }],
-                ))),
-                Stage::topk(LogicalExpr::field("published_year"), 100, true),
-            ]),
+            filter(r#match("love", Some("summary"), None)).top_k(
+                field("published_year"),
+                100,
+                true,
+            ),
             None,
             None,
         )
@@ -78,24 +62,8 @@ async fn test_query_text_filter_two_terms_disjunctive(ctx: &mut ProjectTestConte
         .client
         .collection(&collection.name)
         .query(
-            Query::new(vec![
-                Stage::filter(FilterExpr::text(TextExpr::terms(
-                    false,
-                    vec![
-                        Term {
-                            token: "LOVE".to_string(),
-                            field: Some("summary".to_string()),
-                            weight: 1.0,
-                        },
-                        Term {
-                            token: "ring".to_string(),
-                            field: Some("title".to_string()),
-                            weight: 1.0,
-                        },
-                    ],
-                ))),
-                Stage::topk(LogicalExpr::field("published_year"), 100, true),
-            ]),
+            filter(r#match("LOVE", Some("summary"), None).or(r#match("ring", Some("title"), None)))
+                .top_k(field("published_year"), 100, true),
             None,
             None,
         )
@@ -114,24 +82,12 @@ async fn test_query_text_filter_two_terms_conjunctive(ctx: &mut ProjectTestConte
         .client
         .collection(&collection.name)
         .query(
-            Query::new(vec![
-                Stage::filter(FilterExpr::text(TextExpr::terms(
-                    true,
-                    vec![
-                        Term {
-                            token: "LOVE".to_string(),
-                            field: Some("summary".to_string()),
-                            weight: 1.0,
-                        },
-                        Term {
-                            token: "class".to_string(),
-                            field: Some("summary".to_string()),
-                            weight: 1.0,
-                        },
-                    ],
-                ))),
-                Stage::topk(LogicalExpr::field("published_year"), 100, true),
-            ]),
+            filter(r#match("LOVE", Some("summary"), None).and(r#match(
+                "class",
+                Some("summary"),
+                None,
+            )))
+            .top_k(field("published_year"), 100, true),
             None,
             None,
         )
@@ -150,17 +106,7 @@ async fn test_query_text_filter_stop_word(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            Query::new(vec![
-                Stage::filter(FilterExpr::text(TextExpr::terms(
-                    true,
-                    vec![Term {
-                        token: "the".to_string(),
-                        field: None,
-                        weight: 1.0,
-                    }],
-                ))),
-                Stage::topk(LogicalExpr::field("published_year"), 100, true),
-            ]),
+            filter(r#match("the", Some("summary"), None)).top_k(field("published_year"), 100, true),
             None,
             None,
         )
@@ -179,17 +125,9 @@ async fn test_query_select_bm25_without_text_queries(ctx: &mut ProjectTestContex
         .client
         .collection(&collection.name)
         .query(
-            Query::new(vec![
-                Stage::select(HashMap::from([(
-                    "bm25_score".to_string(),
-                    SelectExpr::function(FunctionExpr::bm25_score()),
-                )])),
-                Stage::filter(FilterExpr::logical(LogicalExpr::eq(
-                    LogicalExpr::field("_id"),
-                    LogicalExpr::literal("pride".into()),
-                ))),
-                Stage::topk(LogicalExpr::field("bm25_score"), 100, true),
-            ]),
+            select([("bm25_score", fns::bm25_score())])
+                .filter(field("_id").eq("pride"))
+                .top_k(field("bm25_score"), 100, true),
             None,
             None,
         )

--- a/topk-rs/tests/test_query_validation.rs
+++ b/topk-rs/tests/test_query_validation.rs
@@ -1,6 +1,7 @@
 use test_context::test_context;
-use topk_protos::v1::data::{LogicalExpr, Query, Stage, Value};
+use topk_protos::v1::data::Value;
 use topk_protos::{doc, schema};
+use topk_rs::query::{field, top_k};
 use topk_rs::Error;
 
 mod utils;
@@ -15,11 +16,7 @@ async fn test_query_topk_by_non_primitive(ctx: &mut ProjectTestContext) {
     let err = ctx
         .client
         .collection(&collection.name)
-        .query(
-            Query::new(vec![Stage::topk(LogicalExpr::field("title"), 3, true)]),
-            None,
-            None,
-        )
+        .query(top_k(field("title"), 3, true), None, None)
         .await
         .expect_err("should have failed");
 
@@ -36,15 +33,7 @@ async fn test_query_topk_by_non_existing(ctx: &mut ProjectTestContext) {
     let err = ctx
         .client
         .collection(&collection.name)
-        .query(
-            Query::new(vec![Stage::topk(
-                LogicalExpr::field("non_existing_field"),
-                3,
-                true,
-            )]),
-            None,
-            None,
-        )
+        .query(top_k(field("non_existing_field"), 3, true), None, None)
         .await
         .expect_err("should have failed");
 
@@ -62,15 +51,7 @@ async fn test_query_topk_limit_zero(ctx: &mut ProjectTestContext) {
     let err = ctx
         .client
         .collection(&collection.name)
-        .query(
-            Query::new(vec![Stage::topk(
-                LogicalExpr::field("published_year"),
-                0,
-                true,
-            )]),
-            None,
-            None,
-        )
+        .query(top_k(field("published_year"), 0, true), None, None)
         .await
         .expect_err("should have failed");
 
@@ -106,18 +87,14 @@ async fn test_union_u32_and_binary(ctx: &mut ProjectTestContext) {
     let _ = ctx
         .client
         .collection(&collection.name)
-        .query(Query::new(vec![Stage::count()]), Some(lsn), None)
+        .count(Some(lsn), None)
         .await
         .expect("could not query");
 
     let err = ctx
         .client
         .collection(&collection.name)
-        .query(
-            Query::new(vec![Stage::topk(LogicalExpr::field("num"), 100, true)]),
-            None,
-            None,
-        )
+        .query(top_k(field("num"), 100, true), None, None)
         .await
         .expect_err("should have failed");
 

--- a/topk-rs/tests/test_query_vector.rs
+++ b/topk-rs/tests/test_query_vector.rs
@@ -1,8 +1,7 @@
-use std::collections::HashMap;
 use test_context::test_context;
-use topk_protos::v1::data::{
-    stage::select_stage::SelectExpr, Document, FunctionExpr, LogicalExpr, Query, Stage, Vector,
-};
+use topk_protos::v1::data::Document;
+use topk_rs::data::function_expr::Vector;
+use topk_rs::query::{field, fns, select};
 
 mod utils;
 use utils::dataset;
@@ -29,22 +28,12 @@ async fn test_query_vector_distance(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            Query::new(vec![
-                Stage::select(HashMap::from([
-                    (
-                        "title".to_string(),
-                        SelectExpr::logical(LogicalExpr::field("title".to_string())),
-                    ),
-                    (
-                        "summary_distance".to_string(),
-                        SelectExpr::function(FunctionExpr::vector_distance(
-                            "summary_embedding".to_string(),
-                            Vector::float(vec![2.0; 16]),
-                        )),
-                    ),
-                ])),
-                Stage::topk(LogicalExpr::field("summary_distance"), 3, true),
-            ]),
+            select([("title", field("title"))])
+                .select([(
+                    "summary_distance",
+                    fns::vector_distance("summary_embedding", vec![2.0; 16]),
+                )])
+                .top_k(field("summary_distance"), 3, true),
             None,
             None,
         )
@@ -65,16 +54,11 @@ async fn test_query_vector_distance_nullable(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            Query::new(vec![
-                Stage::select(HashMap::from([(
-                    "summary_distance".to_string(),
-                    SelectExpr::function(FunctionExpr::vector_distance(
-                        "nullable_embedding".to_string(),
-                        Vector::float(vec![3.0; 16]),
-                    )),
-                )])),
-                Stage::topk(LogicalExpr::field("summary_distance"), 3, true),
-            ]),
+            select([(
+                "summary_distance",
+                fns::vector_distance("nullable_embedding", Vector::float(vec![3.0; 16])),
+            )])
+            .top_k(field("summary_distance"), 3, true),
             None,
             None,
         )
@@ -94,16 +78,11 @@ async fn test_query_vector_distance_u8_vector(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            Query::new(vec![
-                Stage::select(HashMap::from([(
-                    "summary_distance".to_string(),
-                    SelectExpr::function(FunctionExpr::vector_distance(
-                        "scalar_embedding".to_string(),
-                        Vector::byte(vec![8; 16]),
-                    )),
-                )])),
-                Stage::topk(LogicalExpr::field("summary_distance"), 3, true),
-            ]),
+            select([(
+                "summary_distance",
+                fns::vector_distance("scalar_embedding", Vector::byte(vec![8; 16])),
+            )])
+            .top_k(field("summary_distance"), 3, true),
             None,
             None,
         )
@@ -123,16 +102,11 @@ async fn test_query_vector_distance_binary_vector(ctx: &mut ProjectTestContext) 
         .client
         .collection(&collection.name)
         .query(
-            Query::new(vec![
-                Stage::select(HashMap::from([(
-                    "summary_distance".to_string(),
-                    SelectExpr::function(FunctionExpr::vector_distance(
-                        "binary_embedding".to_string(),
-                        Vector::byte(vec![0, 1]),
-                    )),
-                )])),
-                Stage::topk(LogicalExpr::field("summary_distance"), 2, true),
-            ]),
+            select([(
+                "summary_distance",
+                fns::vector_distance("binary_embedding", Vector::byte(vec![0, 1])),
+            )])
+            .top_k(field("summary_distance"), 2, true),
             None,
             None,
         )

--- a/topk-rs/tests/utils/dataset/books.rs
+++ b/topk-rs/tests/utils/dataset/books.rs
@@ -2,7 +2,7 @@ use crate::utils::ProjectTestContext;
 use std::collections::HashMap;
 use topk_protos::v1::{
     control::{Collection, FieldSpec, KeywordIndexType, VectorDistanceMetric},
-    data::{Document, Query, Stage, Value},
+    data::{Document, Value},
 };
 use topk_protos::{doc, schema};
 
@@ -25,7 +25,7 @@ pub async fn setup(ctx: &mut ProjectTestContext) -> Collection {
     let _ = ctx
         .client
         .collection(&collection.name)
-        .query(Query::new(vec![Stage::count()]), Some(lsn), None)
+        .count(Some(lsn), None)
         .await
         .expect("could not query");
 

--- a/topk-rs/tests/utils/dataset/semantic.rs
+++ b/topk-rs/tests/utils/dataset/semantic.rs
@@ -2,7 +2,7 @@ use crate::utils::ProjectTestContext;
 use std::collections::HashMap;
 use topk_protos::v1::{
     control::{Collection, FieldSpec},
-    data::{Document, Query, Stage},
+    data::Document,
 };
 use topk_protos::{doc, schema};
 
@@ -25,7 +25,7 @@ pub async fn setup(ctx: &mut ProjectTestContext) -> Collection {
     let _ = ctx
         .client
         .collection(&collection.name)
-        .query(Query::new(vec![Stage::count()]), Some(lsn), None)
+        .count(Some(lsn), None)
         .await
         .expect("could not query");
 


### PR DESCRIPTION
Instead of constructing protos, use can `use topk_rs::query::{select, field};` and start writing the query like `select([("key", field("my_field"))])`

docs will come later, when we actually publish `topk-rs`