### PR TITLE
Extract query.rerank() arguments into a struct

### DIFF
--- a/topk-js/index.d.ts
+++ b/topk-js/index.d.ts
@@ -55,6 +55,13 @@ export interface QueryOptions {
   consistency?: ConsistencyLevel
 }
 
+export interface RerankOptions {
+  model?: string
+  query?: string
+  fields?: Array<string>
+  topkMultiple?: number
+}
+
 export declare namespace data {
   export class Vector {
     get values(): VectorUnion
@@ -94,7 +101,7 @@ export declare namespace query {
     filter(expr: LogicalExpression | TextExpression): Query
     topk(expr: LogicalExpression, k: number, asc?: boolean | undefined | null): Query
     count(): Query
-    rerank(model?: string | undefined | null, query?: string | undefined | null, fields?: Array<string> | undefined | null, topkMultiple?: number | undefined | null): Query
+    rerank(options?: RerankOptions | undefined | null): Query
   }
   export class TextExpression {
     static create(expr: TextExpressionUnion): TextExpression

--- a/topk-js/package.json
+++ b/topk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "topk-js",
-  "version": "0.1.19-alpha.3",
+  "version": "0.1.19-alpha.4",
   "napi": {
     "binaryName": "topk-js",
     "triples": {

--- a/topk-js/src/query/query.rs
+++ b/topk-js/src/query/query.rs
@@ -87,15 +87,19 @@ impl Query {
     }
 
     #[napi]
-    pub fn rerank(
-        &self,
-        model: Option<String>,
-        query: Option<String>,
-        fields: Option<Vec<String>>,
-        topk_multiple: Option<u32>,
-    ) -> Query {
+    pub fn rerank(&self, options: Option<RerankOptions>) -> Query {
         let mut new_query = Query {
             stages: self.stages.clone(),
+        };
+
+        let (model, query, fields, topk_multiple) = match options {
+            Some(options) => (
+                options.model,
+                options.query,
+                options.fields,
+                options.topk_multiple,
+            ),
+            None => (None, None, None, None),
         };
 
         new_query.stages.push(Stage::Rerank {
@@ -107,6 +111,14 @@ impl Query {
 
         new_query
     }
+}
+
+#[napi(object)]
+pub struct RerankOptions {
+    pub model: Option<String>,
+    pub query: Option<String>,
+    pub fields: Option<Vec<String>>,
+    pub topk_multiple: Option<u32>,
 }
 
 #[napi(namespace = "query")]

--- a/topk-js/tests/semantic_index.spec.ts
+++ b/topk-js/tests/semantic_index.spec.ts
@@ -314,7 +314,7 @@ describe("Semantic Index", () => {
       ctx.client.collection(collection.name).query(
         select({ sim: fn.semanticSimilarity("title", "dummy") })
           .topk(field("sim"), 3, true)
-          .rerank("definitely-does-not-exist")
+          .rerank({ model: "definitely-does-not-exist" })
       )
     ).rejects.toThrow();
   });
@@ -355,7 +355,7 @@ describe("Semantic Index", () => {
     const result = await ctx.client.collection(collection.name).query(
       select({ sim: fn.semanticSimilarity("title", "dummy") })
         .topk(field("sim"), 3, true)
-        .rerank("dummy")
+        .rerank({ model: "dummy" })
     );
 
     expect(result.length).toBe(3);
@@ -412,7 +412,7 @@ describe("Semantic Index", () => {
         summary_sim: fn.semanticSimilarity("summary", "query"),
       })
         .topk(field("title_sim").add(field("summary_sim")), 5, true)
-        .rerank("dummy", "query string", ["title", "summary"])
+        .rerank({ model: "dummy", query: "query string", fields: ["title", "summary"] })
     );
 
     expect(result.length).toBe(5);
@@ -430,6 +430,21 @@ describe("Semantic Index", () => {
       published_year: int(),
     });
 
+    await ctx.client.collection(collection.name).upsert([
+      {
+        _id: "catcher",
+        title: "The Catcher in the Rye",
+        summary: "A story about a young man",
+        published_year: 1951,
+      },
+      {
+        _id: "gatsby",
+        title: "The Great Gatsby",
+        summary: "A story about love and wealth",
+        published_year: 1925,
+      },
+    ]);
+
     await expect(
       ctx.client.collection(collection.name).query(
         select({
@@ -437,7 +452,7 @@ describe("Semantic Index", () => {
           summary_sim: fn.semanticSimilarity("summary", "query"),
         })
           .topk(field("title_sim").add(field("summary_sim")), 5, true)
-          .rerank("dummy")
+          .rerank({ model: "dummy" })
       )
     ).rejects.toThrow();
   });


### PR DESCRIPTION
Instead of passing rerank arguments like:

```ts
.rerank("dummy", "query string", ["title", "summary"])
```

let's extract them into a struct:

```ts
.rerank({ model: "dummy", query: "query string", fields: ["title", "summary"] })
```

* Also: bump topk-js alpha version