### PR TITLE
drop `top_k()` and `count()` query builders

### DIFF
--- a/topk-js/index.d.ts
+++ b/topk-js/index.d.ts
@@ -123,7 +123,6 @@ export declare namespace query {
   'mul'|
   'div';
   export function bm25Score(): FunctionExpression
-  export function count(): Query
   export function field(name: string): LogicalExpression
   export function filter(expr: LogicalExpression | TextExpression): Query
   export type FunctionExpression =
@@ -149,7 +148,6 @@ export declare namespace query {
     | { type: 'Terms', all: boolean, terms: Array<Term> }
     | { type: 'And', left: TextExpression, right: TextExpression }
     | { type: 'Or', left: TextExpression, right: TextExpression }
-  export function topk(expr: LogicalExpression | TextExpression, k: number, asc?: boolean | undefined | null): Query
   export type UnaryOperator =  'not'|
   'isNull'|
   'isNotNull';

--- a/topk-js/lib/query.d.ts
+++ b/topk-js/lib/query.d.ts
@@ -1,6 +1,5 @@
 import { query } from "../index";
 
-export declare const count: typeof query.count;
 export declare const field: typeof query.field;
 export declare const filter: typeof query.filter;
 export declare const fn: {
@@ -16,4 +15,3 @@ export declare const match: typeof query.match;
 export declare const Query: typeof query.Query;
 export declare const select: typeof query.select;
 export declare const TextExpression: typeof query.TextExpression;
-export declare const topk: typeof query.topk;

--- a/topk-js/lib/query.js
+++ b/topk-js/lib/query.js
@@ -1,6 +1,5 @@
 const { query } = require("../index");
 
-module.exports.count = query.count;
 module.exports.field = query.field;
 module.exports.filter = query.filter;
 module.exports.fn = {
@@ -14,4 +13,3 @@ module.exports.match = query.match;
 module.exports.Query = query.Query;
 module.exports.select = query.select;
 module.exports.TextExpression = query.TextExpression;
-module.exports.topk = query.topk;

--- a/topk-js/src/query/query.rs
+++ b/topk-js/src/query/query.rs
@@ -149,32 +149,6 @@ pub fn filter(
 }
 
 #[napi(namespace = "query")]
-pub fn topk(
-    #[napi(ts_arg_type = "LogicalExpression | TextExpression")] expr: LogicalExpression,
-    k: i32,
-    asc: Option<bool>,
-) -> Query {
-    let stage = Stage::TopK {
-        expr,
-        k,
-        asc: asc.unwrap_or(false),
-    };
-
-    Query {
-        stages: vec![stage],
-    }
-}
-
-#[napi(namespace = "query")]
-pub fn count() -> Query {
-    let stage = Stage::Count {};
-
-    Query {
-        stages: vec![stage],
-    }
-}
-
-#[napi(namespace = "query")]
 pub fn field(name: String) -> LogicalExpression {
     LogicalExpression::create(LogicalExpressionUnion::Field { name })
 }

--- a/topk-js/tests/query_count.spec.ts
+++ b/topk-js/tests/query_count.spec.ts
@@ -1,5 +1,5 @@
-import { field, select, count } from "../lib/query";
-import { text, keywordIndex, int } from "../lib/schema";
+import { field, select } from "../lib/query";
+import { int, keywordIndex, text } from "../lib/schema";
 import { newProjectContext, ProjectContext } from "./setup";
 
 describe("Count Queries", () => {
@@ -59,7 +59,11 @@ describe("Count Queries", () => {
       { _id: "catcher", title: "The Catcher in the Rye", published_year: 1951 },
       { _id: "gatsby", title: "The Great Gatsby", published_year: 1925 },
       { _id: "moby", title: "Moby Dick", published_year: 1851 },
-      { _id: "mockingbird", title: "To Kill a Mockingbird", published_year: 1960 },
+      {
+        _id: "mockingbird",
+        title: "To Kill a Mockingbird",
+        published_year: 1960,
+      },
       { _id: "alchemist", title: "The Alchemist", published_year: 1988 },
       { _id: "harry", title: "Harry Potter", published_year: 1997 },
       { _id: "lotr", title: "The Lord of the Rings", published_year: 1954 },
@@ -70,7 +74,7 @@ describe("Count Queries", () => {
 
     const result = await ctx.client
       .collection(collection.name)
-      .query(count().filter(field("published_year").lte(1950)));
+      .query(select({}).filter(field("published_year").lte(1950)).count());
 
     expect(result[0]._count).toBe(5);
   });

--- a/topk-js/tests/query_topk.spec.ts
+++ b/topk-js/tests/query_topk.spec.ts
@@ -1,5 +1,5 @@
-import { field, topk, select } from "../lib/query";
-import { text, keywordIndex, int } from "../lib/schema";
+import { field, select } from "../lib/query";
+import { int, keywordIndex, text } from "../lib/schema";
 import { newProjectContext, ProjectContext } from "./setup";
 
 describe("TopK Queries", () => {
@@ -26,7 +26,11 @@ describe("TopK Queries", () => {
       { _id: "catcher", title: "The Catcher in the Rye", published_year: 1951 },
       { _id: "gatsby", title: "The Great Gatsby", published_year: 1925 },
       { _id: "moby", title: "Moby Dick", published_year: 1851 },
-      { _id: "mockingbird", title: "To Kill a Mockingbird", published_year: 1960 },
+      {
+        _id: "mockingbird",
+        title: "To Kill a Mockingbird",
+        published_year: 1960,
+      },
       { _id: "alchemist", title: "The Alchemist", published_year: 1988 },
       { _id: "harry", title: "Harry Potter", published_year: 1997 },
       { _id: "lotr", title: "The Lord of the Rings", published_year: 1954 },
@@ -37,7 +41,9 @@ describe("TopK Queries", () => {
 
     const results = await ctx.client
       .collection(collection.name)
-      .query(topk(field("published_year"), 5, true));
+      .query(
+        select({ title: field("title") }).topk(field("published_year"), 5, true)
+      );
 
     expect(results.map((doc) => doc._id)).toEqual([
       "pride",
@@ -74,10 +80,7 @@ describe("TopK Queries", () => {
 
     const results = await ctx.client
       .collection(collection.name)
-      .query(
-        select({})
-          .topk(field("published_year"), 5, false)
-      );
+      .query(select({}).topk(field("published_year"), 5, false));
 
     expect(results.map((doc) => doc._id)).toEqual([
       "harry",
@@ -114,10 +117,7 @@ describe("TopK Queries", () => {
 
     const results = await ctx.client
       .collection(collection.name)
-      .query(
-        select({})
-          .topk(field("published_year"), 20, true)
-      );
+      .query(select({}).topk(field("published_year"), 20, true));
 
     expect(results.length).toBe(10);
     expect(results[0]._id).toBe("pride");
@@ -133,10 +133,7 @@ describe("TopK Queries", () => {
 
     const results = await ctx.client
       .collection(collection.name)
-      .query(
-        select({})
-          .topk(field("published_year"), 5, true)
-      );
+      .query(select({}).topk(field("published_year"), 5, true));
 
     expect(results.length).toBe(0);
   });

--- a/topk-py/src/query/mod.rs
+++ b/topk-py/src/query/mod.rs
@@ -29,8 +29,6 @@ pub fn pymodule(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     m.add_wrapped(wrap_pyfunction!(select))?;
     m.add_wrapped(wrap_pyfunction!(filter))?;
-    m.add_wrapped(wrap_pyfunction!(top_k))?;
-    m.add_wrapped(wrap_pyfunction!(count))?;
     m.add_wrapped(wrap_pyfunction!(field))?;
     m.add_wrapped(wrap_pyfunction!(literal))?;
     m.add_wrapped(wrap_pyfunction!(r#match))?;
@@ -51,17 +49,6 @@ pub fn select(
 #[pyo3(signature = (expr))]
 pub fn filter(expr: FilterExprUnion) -> PyResult<Query> {
     Ok(Query::new().filter(expr)?)
-}
-
-#[pyfunction]
-#[pyo3(signature = (expr, k, asc=true))]
-pub fn top_k(expr: LogicalExpr, k: u64, asc: bool) -> PyResult<Query> {
-    Ok(Query::new().top_k(expr, k, asc)?)
-}
-
-#[pyfunction]
-pub fn count() -> PyResult<Query> {
-    Query::new().count()
 }
 
 #[pyfunction]

--- a/topk-py/tests/test_delete.py
+++ b/topk-py/tests/test_delete.py
@@ -1,6 +1,6 @@
 import pytest
 from topk_sdk import error
-from topk_sdk.query import field, top_k
+from topk_sdk.query import field, select
 
 from . import ProjectContext
 from .utils import doc_ids
@@ -29,7 +29,7 @@ def test_delete_document(ctx: ProjectContext):
     assert lsn == 2
 
     docs = ctx.client.collection(collection.name).query(
-        top_k(field("rank"), 100, True), lsn=lsn
+        select("title").top_k(field("rank"), 100, True), lsn=lsn
     )
 
     assert doc_ids(docs) == {"two"}

--- a/topk-py/tests/test_query_select.py
+++ b/topk-py/tests/test_query_select.py
@@ -1,4 +1,4 @@
-from topk_sdk.query import field, fn, literal, match, select, top_k
+from topk_sdk.query import field, fn, literal, match, select
 
 from . import ProjectContext
 from .utils import dataset, doc_ids
@@ -32,17 +32,17 @@ def test_query_topk_limit(ctx: ProjectContext):
     collection = dataset.books.setup(ctx)
 
     results = ctx.client.collection(collection.name).query(
-        top_k(field("published_year"), 3, True)
+        select("title").top_k(field("published_year"), 3, True)
     )
     assert len(results) == 3
 
     results = ctx.client.collection(collection.name).query(
-        top_k(field("published_year"), 2, True)
+        select("title").top_k(field("published_year"), 2, True)
     )
     assert len(results) == 2
 
     results = ctx.client.collection(collection.name).query(
-        top_k(field("published_year"), 1, True)
+        select("title").top_k(field("published_year"), 1, True)
     )
     assert len(results) == 1
 

--- a/topk-py/tests/test_query_validation.py
+++ b/topk-py/tests/test_query_validation.py
@@ -1,6 +1,6 @@
 import pytest
 from topk_sdk import error
-from topk_sdk.query import field, top_k
+from topk_sdk.query import field, select
 
 from . import ProjectContext
 from .utils import dataset
@@ -10,7 +10,9 @@ def test_query_topk_by_non_primitive(ctx: ProjectContext):
     collection = dataset.books.setup(ctx)
 
     with pytest.raises(error.InvalidArgumentError) as exc_info:
-        ctx.client.collection(collection.name).query(top_k(field("title"), 3, True))
+        ctx.client.collection(collection.name).query(
+            select("title").top_k(field("title"), 3, True)
+        )
     assert "Input to SortWithLimit must produce primitive type, not String" in str(
         exc_info.value
     )
@@ -21,7 +23,7 @@ def test_query_topk_by_non_existing(ctx: ProjectContext):
 
     with pytest.raises(error.InvalidArgumentError) as exc_info:
         ctx.client.collection(collection.name).query(
-            top_k(field("non_existing_field"), 3, True)
+            select("title").top_k(field("non_existing_field"), 3, True)
         )
     assert "Input to SortWithLimit must produce primitive type, not Null" in str(
         exc_info.value
@@ -33,7 +35,7 @@ def test_query_topk_limit_zero(ctx: ProjectContext):
 
     with pytest.raises(error.InvalidArgumentError) as exc_info:
         ctx.client.collection(collection.name).query(
-            top_k(field("published_year"), 0, True)
+            select("title").top_k(field("published_year"), 0, True)
         )
     assert "Invalid argument: TopK k must be > 0" in str(exc_info.value)
 
@@ -51,5 +53,7 @@ def test_union_u32_and_binary(ctx: ProjectContext):
     ctx.client.collection(collection.name).count(lsn=lsn)
 
     with pytest.raises(error.InvalidArgumentError) as exc_info:
-        ctx.client.collection(collection.name).query(top_k(field("num"), 100, True))
+        ctx.client.collection(collection.name).query(
+            select("title").top_k(field("num"), 100, True)
+        )
     assert "Input to SortWithLimit must produce primitive type" in str(exc_info.value)

--- a/topk-rs/src/query/mod.rs
+++ b/topk-rs/src/query/mod.rs
@@ -28,13 +28,8 @@ where
     Query::new(vec![]).select(exprs)
 }
 
-// TODO: `filter` and `top_k` are not exported from python
 pub fn filter(expr: impl Into<FilterExpr>) -> Query {
     Query::new(vec![]).filter(expr.into())
-}
-
-pub fn top_k(expr: impl Into<LogicalExpr>, limit: u64, asc: bool) -> Query {
-    Query::new(vec![]).top_k(expr, limit, asc)
 }
 
 pub fn field<S>(name: S) -> LogicalExpr

--- a/topk-rs/tests/test_delete.rs
+++ b/topk-rs/tests/test_delete.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use test_context::test_context;
 use topk_protos::doc;
-use topk_rs::query::{field, top_k};
+use topk_rs::query::{field, select};
 use topk_rs::Error;
 
 mod utils;
@@ -59,7 +59,11 @@ async fn test_delete_document(ctx: &mut ProjectTestContext) {
     let docs = ctx
         .client
         .collection(&collection.name)
-        .query(top_k(field("rank"), 100, true), Some(lsn), None)
+        .query(
+            select([("title", field("title"))]).top_k(field("published_year"), 100, true),
+            Some(lsn),
+            None,
+        )
         .await
         .expect("could not query documents");
 

--- a/topk-rs/tests/test_delete.rs
+++ b/topk-rs/tests/test_delete.rs
@@ -60,7 +60,7 @@ async fn test_delete_document(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            select([("title", field("title"))]).top_k(field("published_year"), 100, true),
+            select([("title", field("title"))]).top_k(field("rank"), 100, true),
             Some(lsn),
             None,
         )

--- a/topk-rs/tests/test_query_select.rs
+++ b/topk-rs/tests/test_query_select.rs
@@ -5,7 +5,7 @@ use topk_protos::v1::data::Value;
 
 mod utils;
 use topk_rs::data::Vector;
-use topk_rs::query::{field, fns, literal, r#match, select, top_k};
+use topk_rs::query::{field, fns, literal, r#match, select};
 use utils::dataset;
 use utils::ProjectTestContext;
 
@@ -59,7 +59,11 @@ async fn test_query_topk_limit(ctx: &mut ProjectTestContext) {
     let results = ctx
         .client
         .collection(&collection.name)
-        .query(top_k(field("published_year"), 3, true), None, None)
+        .query(
+            select([("title", field("title"))]).top_k(field("published_year"), 3, true),
+            None,
+            None,
+        )
         .await
         .expect("could not query");
     assert_eq!(results.len(), 3);
@@ -67,7 +71,11 @@ async fn test_query_topk_limit(ctx: &mut ProjectTestContext) {
     let results = ctx
         .client
         .collection(&collection.name)
-        .query(top_k(field("published_year"), 2, true), None, None)
+        .query(
+            select([("title", field("title"))]).top_k(field("published_year"), 2, true),
+            None,
+            None,
+        )
         .await
         .expect("could not query");
     assert_eq!(results.len(), 2);
@@ -75,7 +83,11 @@ async fn test_query_topk_limit(ctx: &mut ProjectTestContext) {
     let results = ctx
         .client
         .collection(&collection.name)
-        .query(top_k(field("published_year"), 1, true), None, None)
+        .query(
+            select([("title", field("title"))]).top_k(field("published_year"), 1, true),
+            None,
+            None,
+        )
         .await
         .expect("could not query");
     assert_eq!(results.len(), 1);

--- a/topk-rs/tests/test_query_validation.rs
+++ b/topk-rs/tests/test_query_validation.rs
@@ -1,7 +1,7 @@
 use test_context::test_context;
 use topk_protos::v1::data::Value;
 use topk_protos::{doc, schema};
-use topk_rs::query::{field, top_k};
+use topk_rs::query::{field, select};
 use topk_rs::Error;
 
 mod utils;
@@ -16,7 +16,11 @@ async fn test_query_topk_by_non_primitive(ctx: &mut ProjectTestContext) {
     let err = ctx
         .client
         .collection(&collection.name)
-        .query(top_k(field("title"), 3, true), None, None)
+        .query(
+            select([("title", field("title"))]).top_k(field("title"), 3, true),
+            None,
+            None,
+        )
         .await
         .expect_err("should have failed");
 
@@ -33,7 +37,11 @@ async fn test_query_topk_by_non_existing(ctx: &mut ProjectTestContext) {
     let err = ctx
         .client
         .collection(&collection.name)
-        .query(top_k(field("non_existing_field"), 3, true), None, None)
+        .query(
+            select([("title", field("title"))]).top_k(field("non_existing_field"), 3, true),
+            None,
+            None,
+        )
         .await
         .expect_err("should have failed");
 
@@ -51,7 +59,11 @@ async fn test_query_topk_limit_zero(ctx: &mut ProjectTestContext) {
     let err = ctx
         .client
         .collection(&collection.name)
-        .query(top_k(field("published_year"), 0, true), None, None)
+        .query(
+            select([("title", field("title"))]).top_k(field("published_year"), 0, true),
+            None,
+            None,
+        )
         .await
         .expect_err("should have failed");
 
@@ -94,7 +106,11 @@ async fn test_union_u32_and_binary(ctx: &mut ProjectTestContext) {
     let err = ctx
         .client
         .collection(&collection.name)
-        .query(top_k(field("num"), 100, true), None, None)
+        .query(
+            select([("title", field("title"))]).top_k(field("num"), 100, true),
+            None,
+            None,
+        )
         .await
         .expect_err("should have failed");
 


### PR DESCRIPTION
It makes sense to let users start queries with `select()` or `filter()`. 

* `top_k()` on its own is not very useful as you'd only get the `_id` field back. forcing user to use `select()` makes it explicit what data is going to be returned
* `client.collection().query(count())` can be written as `client.collection().count()` so no need to export `count()` too