### PR TITLE
pass struct to vector field constructors | make semantic index arguments optional

### DIFF
--- a/topk-js/index.d.ts
+++ b/topk-js/index.d.ts
@@ -162,7 +162,7 @@ export declare namespace schema {
     required(): FieldSpec
     index(index: FieldIndex): FieldSpec
   }
-  export function binaryVector(dimension: number): FieldSpec
+  export function binaryVector(options: VectorOptions): FieldSpec
   export function bool(): FieldSpec
   export function bytes(): FieldSpec
   export type DataType =
@@ -177,7 +177,7 @@ export declare namespace schema {
   export type EmbeddingDataType =  'float32'|
   'uint8'|
   'binary';
-  export function f32Vector(dimension: number): FieldSpec
+  export function f32Vector(options: VectorOptions): FieldSpec
   export interface FieldIndex {
     index?: FieldIndexUnion
   }
@@ -189,13 +189,13 @@ export declare namespace schema {
   export function int(): FieldSpec
   export function keywordIndex(): FieldIndex
   export type KeywordIndexType =  'text';
-  export function semanticIndex(options: SemanticIndexOptions): FieldIndex
+  export function semanticIndex(options?: SemanticIndexOptions | undefined | null): FieldIndex
   export interface SemanticIndexOptions {
     model?: string
     embeddingType?: EmbeddingDataType
   }
   export function text(): FieldSpec
-  export function u8Vector(dimension: number): FieldSpec
+  export function u8Vector(options: VectorOptions): FieldSpec
   export type VectorDistanceMetric =  'cosine'|
   'euclidean'|
   'dot_product'|
@@ -203,5 +203,8 @@ export declare namespace schema {
   export function vectorIndex(options: VectorIndexOptions): FieldIndex
   export interface VectorIndexOptions {
     metric: VectorDistanceMetric
+  }
+  export interface VectorOptions {
+    dimension: number
   }
 }

--- a/topk-js/package.json
+++ b/topk-js/package.json
@@ -84,7 +84,7 @@
     "build:debug": "napi build --no-const-enum --platform",
     "prepublishOnly": "napi prepublish -t npm --no-gh-release",
     "typecheck": "tsc --noEmit",
-    "test": "jest --verbose",
+    "test": "yarn typecheck && jest --verbose",
     "universal": "napi universalize",
     "version": "napi version"
   }

--- a/topk-js/package.json
+++ b/topk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "topk-js",
-  "version": "0.1.19-alpha.4",
+  "version": "0.1.19-alpha.5",
   "napi": {
     "binaryName": "topk-js",
     "triples": {

--- a/topk-js/package.json
+++ b/topk-js/package.json
@@ -83,6 +83,7 @@
     "dev": "napi build --no-const-enum --platform",
     "build:debug": "napi build --no-const-enum --platform",
     "prepublishOnly": "napi prepublish -t npm --no-gh-release",
+    "typecheck": "tsc --noEmit",
     "test": "jest --verbose",
     "universal": "napi universalize",
     "version": "napi version"

--- a/topk-js/src/schema/mod.rs
+++ b/topk-js/src/schema/mod.rs
@@ -29,19 +29,30 @@ pub fn bool() -> FieldSpec {
     FieldSpec::create(DataType::Boolean {})
 }
 
-#[napi(namespace = "schema")]
-pub fn f32_vector(dimension: u32) -> FieldSpec {
-    FieldSpec::create(DataType::F32Vector { dimension })
+#[napi(object, namespace = "schema")]
+pub struct VectorOptions {
+    pub dimension: u32,
 }
 
 #[napi(namespace = "schema")]
-pub fn u8_vector(dimension: u32) -> FieldSpec {
-    FieldSpec::create(DataType::U8Vector { dimension })
+pub fn f32_vector(options: VectorOptions) -> FieldSpec {
+    FieldSpec::create(DataType::F32Vector {
+        dimension: options.dimension,
+    })
 }
 
 #[napi(namespace = "schema")]
-pub fn binary_vector(dimension: u32) -> FieldSpec {
-    FieldSpec::create(DataType::BinaryVector { dimension })
+pub fn u8_vector(options: VectorOptions) -> FieldSpec {
+    FieldSpec::create(DataType::U8Vector {
+        dimension: options.dimension,
+    })
+}
+
+#[napi(namespace = "schema")]
+pub fn binary_vector(options: VectorOptions) -> FieldSpec {
+    FieldSpec::create(DataType::BinaryVector {
+        dimension: options.dimension,
+    })
 }
 
 #[napi(namespace = "schema")]
@@ -79,11 +90,16 @@ pub struct SemanticIndexOptions {
 }
 
 #[napi(namespace = "schema")]
-pub fn semantic_index(options: SemanticIndexOptions) -> FieldIndex {
+pub fn semantic_index(options: Option<SemanticIndexOptions>) -> FieldIndex {
+    let (model, embedding_type) = match options {
+        Some(options) => (options.model, options.embedding_type),
+        None => (None, None),
+    };
+
     FieldIndex {
         index: Some(FieldIndexUnion::SemanticIndex {
-            model: options.model,
-            embedding_type: options.embedding_type,
+            model,
+            embedding_type,
         }),
     }
 }

--- a/topk-js/tests/collections.spec.ts
+++ b/topk-js/tests/collections.spec.ts
@@ -30,7 +30,7 @@ describe("Collections", () => {
 
     const schema = {
       title: text(),
-      title_embedding: f32Vector(1536)
+      title_embedding: f32Vector({ dimension: 1536 })
         .required()
         .index(vectorIndex({ metric: "euclidean" })),
       summary: text()
@@ -73,10 +73,10 @@ describe("Collections", () => {
       int: int(),
       float: float(),
       bool: bool(),
-      vector: f32Vector(1536),
-      float_vector: f32Vector(1536),
-      byte_vector: u8Vector(1536),
-      binary_vector: binaryVector(1536),
+      vector: f32Vector({ dimension: 1536 }),
+      float_vector: f32Vector({ dimension: 1536 }),
+      byte_vector: u8Vector({ dimension: 1536 }),
+      binary_vector: binaryVector({ dimension: 1536 }),
       bytes: bytes(),
     };
 

--- a/topk-js/tests/documents.spec.ts
+++ b/topk-js/tests/documents.spec.ts
@@ -118,7 +118,7 @@ describe("Documents", () => {
     const ctx = getContext();
 
     await ctx.createCollection("books", {
-      f32_embedding: f32Vector(3)
+      f32_embedding: f32Vector({ dimension: 3 })
         .required()
         .index(vectorIndex({ metric: "euclidean" })),
     });
@@ -145,7 +145,7 @@ describe("Documents", () => {
     const ctx = getContext();
 
     await ctx.createCollection("books", {
-      u8_embedding: u8Vector(3)
+      u8_embedding: u8Vector({ dimension: 3 })
         .required()
         .index(vectorIndex({ metric: "euclidean" })),
     });
@@ -175,7 +175,7 @@ describe("Documents", () => {
     const ctx = getContext();
 
     await ctx.createCollection("books", {
-      binary_embedding: binaryVector(3)
+      binary_embedding: binaryVector({ dimension: 3 })
         .required()
         .index(vectorIndex({ metric: "hamming" })),
     });

--- a/topk-js/tests/query_select.spec.ts
+++ b/topk-js/tests/query_select.spec.ts
@@ -176,7 +176,7 @@ describe("Select Queries", () => {
   test("query select vector distance", async () => {
     const ctx = getContext();
     const collection = await ctx.createCollection("books", {
-      summary_embedding: f32Vector(16)
+      summary_embedding: f32Vector({ dimension: 16 })
         .required()
         .index(vectorIndex({ metric: "euclidean" })),
     });

--- a/topk-js/tests/query_vector.spec.ts
+++ b/topk-js/tests/query_vector.spec.ts
@@ -34,7 +34,7 @@ describe("Vector Queries", () => {
     const ctx = getContext();
     const collection = await ctx.createCollection("books", {
       title: text(),
-      summary_embedding: f32Vector(16)
+      summary_embedding: f32Vector({ dimension: 16 })
         .required()
         .index(vectorIndex({ metric: "euclidean" })),
     });
@@ -79,7 +79,7 @@ describe("Vector Queries", () => {
   test("query vector distance nullable", async () => {
     const ctx = getContext();
     const collection = await ctx.createCollection("books", {
-      nullable_embedding: f32Vector(16).index(
+      nullable_embedding: f32Vector({ dimension: 16 }).index(
         vectorIndex({ metric: "euclidean" })
       ),
     });
@@ -108,7 +108,7 @@ describe("Vector Queries", () => {
   test("query vector distance u8 vector", async () => {
     const ctx = getContext();
     const collection = await ctx.createCollection("books", {
-      scalar_embedding: u8Vector(16)
+      scalar_embedding: u8Vector({ dimension: 16 })
         .required()
         .index(vectorIndex({ metric: "euclidean" })),
     });
@@ -146,7 +146,7 @@ describe("Vector Queries", () => {
   test("query vector distance binary vector", async () => {
     const ctx = getContext();
     const collection = await ctx.createCollection("books", {
-      binary_embedding: binaryVector(2)
+      binary_embedding: binaryVector({ dimension: 2 })
         .required()
         .index(vectorIndex({ metric: "hamming" })),
     });


### PR DESCRIPTION
Fixes https://github.com/fafolabs/topk-sdk/issues/42

* pass `options: VectorOptions` struct to `binaryVector(...)`, `f32Vector(...)` and `u8Vector(...)` schema constructors
  ```typescript
    export interface VectorOptions {
      dimension: number
    }
  ```

* make `semanticIndex(options?: SemanticIndexOptions | undefined | null)` argument optional
* add typecheck command for typechecking tests