### PR TITLE
[publish] remove publish on tag

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -2,7 +2,7 @@ name: Build & publish JS SDK
 env:
   DEBUG: napi:*
   APP_NAME: topk-js
-  MACOSX_DEPLOYMENT_TARGET: '10.13'
+  MACOSX_DEPLOYMENT_TARGET: "10.13"
   DISABLE_V8_COMPILE_CACHE: 1
 permissions:
   contents: write
@@ -10,17 +10,14 @@ permissions:
 defaults:
   run:
     working-directory: ./topk-js
-'on':
-  push:
-    tags:
-      - "*"
-    paths-ignore:
-      - '**/*.md'
-      - LICENSE
-      - '**/*.gitignore'
-      - .editorconfig
-      - docs/**
+"on":
   workflow_dispatch:
+    inputs:
+      publish:
+        type: boolean
+        description: "Whether to publish the release to npm"
+        default: false
+
 jobs:
   build:
     timeout-minutes: 30
@@ -180,7 +177,7 @@ jobs:
         if: ${{ matrix.settings.docker }}
         with:
           image: ${{ matrix.settings.docker }}
-          options: '--user 0:0 -v ${{ github.workspace }}/.cargo-cache/git/db:/usr/local/cargo/git/db -v ${{ github.workspace }}/.cargo/registry/cache:/usr/local/cargo/registry/cache -v ${{ github.workspace }}/.cargo/registry/index:/usr/local/cargo/registry/index -v ${{ github.workspace }}:/build -w /build/topk-js'
+          options: "--user 0:0 -v ${{ github.workspace }}/.cargo-cache/git/db:/usr/local/cargo/git/db -v ${{ github.workspace }}/.cargo/registry/cache:/usr/local/cargo/registry/cache -v ${{ github.workspace }}/.cargo/registry/index:/usr/local/cargo/registry/index -v ${{ github.workspace }}:/build -w /build/topk-js"
           run: |
             set -e
 
@@ -278,8 +275,8 @@ jobs:
           - host: windows-latest
             target: x86_64-pc-windows-msvc
         node:
-          - '20'
-          - '22'
+          - "20"
+          - "22"
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v4
@@ -312,8 +309,8 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - '20'
-          - '22'
+          - "20"
+          - "22"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -345,8 +342,8 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - '20'
-          - '22'
+          - "20"
+          - "22"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -380,8 +377,8 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - '20'
-          - '22'
+          - "20"
+          - "22"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -409,7 +406,7 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: node:${{ matrix.node }}-slim
-          options: '--platform linux/arm64 -v ${{ github.workspace }}:/build -w /build/topk-js -e TOPK_API_KEY'
+          options: "--platform linux/arm64 -v ${{ github.workspace }}:/build -w /build/topk-js -e TOPK_API_KEY"
           run: |
             set -e
             apt-get update && apt-get install ca-certificates -y
@@ -446,7 +443,7 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: node:lts-alpine
-          options: '--platform linux/arm64 -v ${{ github.workspace }}:/build -w /build/topk-js -e TOPK_API_KEY'
+          options: "--platform linux/arm64 -v ${{ github.workspace }}:/build -w /build/topk-js -e TOPK_API_KEY"
           run: |
             set -e
             apt-get update && apt-get install ca-certificates -y
@@ -459,8 +456,8 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - '20'
-          - '22'
+          - "20"
+          - "22"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -489,7 +486,7 @@ jobs:
         uses: addnab/docker-run-action@v3
         with:
           image: node:${{ matrix.node }}-bookworm-slim
-          options: '--platform linux/arm/v7 -v ${{ github.workspace }}:/build -w /build/topk-js -e TOPK_API_KEY'
+          options: "--platform linux/arm/v7 -v ${{ github.workspace }}:/build -w /build/topk-js -e TOPK_API_KEY"
           run: |
             set -e
             apt-get update
@@ -532,7 +529,7 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    if: ${{ inputs.publish }}
     needs:
       - test-macOS-windows-binding
       - test-linux-x64-gnu-binding

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,38 +6,18 @@
 name: Build & publish Python SDK
 
 on:
-  push:
-    tags:
-      - "*"
   workflow_dispatch:
     inputs:
-      release_version:
-        type: string
-        description: "The version to release"
-
-env:
-  RELEASE_VERSION: ${{ inputs.release_version || github.ref_name }}
+      publish:
+        type: boolean
+        description: "Whether to publish the release to PyPI"
+        default: false
 
 permissions:
   contents: read
 
 jobs:
-  check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Check version matches tag
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          CRATE_VERSION=$(grep '^version' topk-py/Cargo.toml | sed -E 's/version = "(.*)"/\1/')
-
-          if [ "$CRATE_VERSION" != "$RELEASE_VERSION" ]; then
-            echo "Version in Cargo.toml ($CRATE_VERSION) does not match tag ($RELEASE_VERSION)"
-            exit 1
-          fi
-
   linux:
-    needs: check
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
@@ -76,7 +56,6 @@ jobs:
           path: topk-py/dist
 
   musllinux:
-    needs: check
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
@@ -111,7 +90,6 @@ jobs:
           path: topk-py/dist
 
   windows:
-    needs: check
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
@@ -152,7 +130,6 @@ jobs:
           path: topk-py/dist
 
   macos:
-    needs: check
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
@@ -187,7 +164,6 @@ jobs:
           path: topk-py/dist
 
   sdist:
-    needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -205,7 +181,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
+    if: ${{ inputs.publish }}
     needs: [linux, musllinux, windows, macos, sdist]
     permissions:
       # Use to sign the release artifacts

--- a/topk-py/Cargo.toml
+++ b/topk-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topk-py"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 description = "TopK Python SDK"
 license-file = "LICENSE"


### PR DESCRIPTION
Since this is a polyglot repo and we decided that we do not want a "bundled" (all sdks at once) release strategy, I'm removing GH triggers (`on: push: tags`). Each workflow can be dispatched manually from GH UI.

Also bumping python version.